### PR TITLE
fix windows using wrong file name

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -1,7 +1,7 @@
 /*!
 GitHub releases
 */
-use std::env;
+use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
 use hyper_old_types::header::{LinkValue, RelationType};
@@ -276,9 +276,11 @@ impl UpdateBuilder {
     }
 
     /// Set the exe's name. Also sets `bin_path_in_archive` if it hasn't already been set.
+    ///
+    /// This method does append platform specific executable file suffixes to the name if needed.
     pub fn bin_name(&mut self, name: &str) -> &mut Self {
-        let raw_bin_name = format!("{}{}", name, EXECUTABLE_SUFFIX);
-        self.bin_name = Some(raw_bin_name.to_owned());
+        let raw_bin_name = format!("{}{}", name.trim_end_matches(EXE_SUFFIX), EXE_SUFFIX);
+        self.bin_name = Some(raw_bin_name.clone());
         if self.bin_path_in_archive.is_none() {
             self.bin_path_in_archive = Some(PathBuf::from(raw_bin_name));
         }

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -277,9 +277,10 @@ impl UpdateBuilder {
 
     /// Set the exe's name. Also sets `bin_path_in_archive` if it hasn't already been set.
     pub fn bin_name(&mut self, name: &str) -> &mut Self {
-        self.bin_name = Some(name.to_owned());
+        let raw_bin_name = format!("{}{}", name, EXECUTABLE_SUFFIX);
+        self.bin_name = Some(raw_bin_name.to_owned());
         if self.bin_path_in_archive.is_none() {
-            self.bin_path_in_archive = Some(PathBuf::from(name));
+            self.bin_path_in_archive = Some(PathBuf::from(raw_bin_name));
         }
         self
     }


### PR DESCRIPTION
I just tested the crate under Windows and it fails because the updater can't find the binary name without the `exe` file extension.

Fixes #21.