### PR TITLE
Add syntax highlighting to second README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and `asset_prefix` string, `self_update` will look up all matching files using t
 as a convention for the filenames: `<asset name>-<semver>-<platform/target>.<extension>`.
 Any file not matching the format, or not matching the provided prefix string, is be ignored.
 
-```
+```rust
 fn update() -> Result<(), Box<::std::error::Error>> {
     let status = self_update::backends::s3::Update::configure()
         .bucket_owner("self_update_releases")


### PR DESCRIPTION
Add the `rust` tag to the second example's code block so that syntax highlighting will be applied.