### PR TITLE
feat/rust-tls: Feature flag to use rust tls instead of native dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
-    - env: TARGET=i686-apple-darwin
-      os: osx
+    # - env: TARGET=i686-apple-darwin
+    #   os: osx
     - env: TARGET=x86_64-apple-darwin
       os: osx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Feature flag `rustls` to enable using [rustls](https://github.com/ctz/rustls) instead of native openssl implementations.
 ### Changed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [dependencies]
 serde_json = "1"
-reqwest = { version = "0.10", features = ["blocking", "json"]}
 tempdir = "0.3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
@@ -26,13 +25,19 @@ quick-xml = "0.17.2"
 regex = "1.3.1"
 
 [features]
-default = []
+default = ["reqwest/default-tls"]
 archive-zip = ["zip"]
 compression-zip-bzip2 = ["zip/bzip2"] #
 compression-zip-deflate = ["zip/deflate"] #
 archive-tar = ["tar"]
 compression-flate2 = ["flate2", "either"] #
+rustls = ["reqwest/rustls-tls"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)
 all-features = true
+
+[dependencies.reqwest]
+version = "0.10"
+default-features = false
+features = ["blocking", "json"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ available (but _disabled_ by default):
 * `compression-flate2`: Support for _gzip_ compression;
 * `compression-zip-deflate`: Support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: Support for _zip_'s _bzip2_ compression format;
-* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests.;
+* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests. This feature does _not_ support 32bit macOS;
 
 Please active the feature(s) needed by your release files.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ available (but _disabled_ by default):
 * `compression-flate2`: Support for _gzip_ compression;
 * `compression-zip-deflate`: Support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: Support for _zip_'s _bzip2_ compression format;
+* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests.;
 
 Please active the feature(s) needed by your release files.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ available (but _disabled_ by default):
 * `compression-flate2`: Support for _gzip_ compression;
 * `compression-zip-deflate`: Support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: Support for _zip_'s _bzip2_ compression format;
-* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests.;
+* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests. This feature does _not_ support 32bit macOS;
 
 Please active the feature(s) needed by your release files.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ available (but _disabled_ by default):
 * `compression-flate2`: Support for _gzip_ compression;
 * `compression-zip-deflate`: Support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: Support for _zip_'s _bzip2_ compression format;
+* `rustls`: Use [pure rust TLS implementation](https://github.com/ctz/rustls) for network requests.;
 
 Please active the feature(s) needed by your release files.
 


### PR DESCRIPTION
Enable opt-in use of pure tls implementation, to avoid `reqwest` using native openssl implementations (which can be problematic on linux)