### PR TITLE
Added optional 'v' character in regex, logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 ### Added
+- Handling for `.tgz` files
 ### Changed
+- Support version tags with or without leading `v`
+- S3, support path prefixes that contain directories
 ### Removed
 
 ## [0.14.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ either = { version = "1.5.0", optional = true }
 indicatif = "0.13.0"
 quick-xml = "0.17.2"
 regex = "1.3.1"
+log = "0.4.8"
 
 [features]
 default = ["reqwest/default-tls"]

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Run the above example to see `self_update` in action: `cargo run --example githu
 
 Amazon S3 is also supported as the backend to check for new releases. Provided a `bucket_name`
 and `asset_prefix` string, `self_update` will look up all matching files using the following format
-as a convention for the filenames: `<asset name>-<semver>-<platform/target>.<extension>`.
-Any file not matching the format, or not matching the provided prefix string, will be ignored.
+as a convention for the filenames: `[directory/]<asset name>-<semver>-<platform/target>.<extension>`.
+Leading directories will be stripped from the file name allowing the use of subdirectories in the S3 bucket, and any file not matching the format, or not matching the provided prefix string, will be ignored.
 
 ```rust
 use self_update::cargo_crate_version;
@@ -68,7 +68,7 @@ use self_update::cargo_crate_version;
 fn update() -> Result<(), Box<::std::error::Error>> {
     let status = self_update::backends::s3::Update::configure()
         .bucket_name("self_update_releases")
-        .asset_prefix("self_update")
+        .asset_prefix("something/self_update")
         .region("eu-west-2")
         .bin_name("self_update_example")
         .show_download_progress(true)

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -458,6 +458,8 @@ fn fetch_releases_from_s3(
         bucket_name, MAX_KEYS, prefix
     );
 
+    debug!("using api url: {:?}", api_url);
+
     let download_base_url = format!("https://{}.s3.{}.amazonaws.com/", bucket_name, region);
 
     let resp = reqwest::blocking::Client::new().get(&api_url).send()?;
@@ -484,7 +486,7 @@ fn fetch_releases_from_s3(
 
     let mut current_tag = Tag::Other;
     let mut current_release: Option<Release> = None;
-    let regex = Regex::new(r"(?i)(?P<name>.+)-(?P<version>\d+\.\d+\.\d+)-.+").map_err(|err| {
+    let regex = Regex::new(r"(?i)(?P<name>.+)-[v]{0,1}(?P<version>\d+\.\d+\.\d+)-.+").map_err(|err| {
         Error::Release(format!(
             "Failed constructing regex to parse S3 filenames: {}",
             err
@@ -522,6 +524,9 @@ fn fetch_releases_from_s3(
                                     name: txt.clone(),
                                     download_url: format!("{}{}", download_base_url, txt),
                                 }];
+                                debug!("Matched release: {:?}", release);
+                            } else {
+                                debug!("Regex mismatch: {:?}", &txt);
                             }
                         }
                         Tag::LastModified => {

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -442,8 +442,10 @@ impl ReleaseUpdate for Update {
     }
 }
 
-// Obtain list of releases from AWS S3 API, from bucket and region specified,
-// filtering assets which don't match the prefix string if provided
+/// Obtain list of releases from AWS S3 API, from bucket and region specified,
+/// filtering assets which don't match the prefix string if provided.
+///
+/// This will strip the prefix from provided file names, allowing use with subdirectories
 fn fetch_releases_from_s3(
     bucket_name: &str,
     region: &str,
@@ -486,12 +488,14 @@ fn fetch_releases_from_s3(
 
     let mut current_tag = Tag::Other;
     let mut current_release: Option<Release> = None;
-    let regex = Regex::new(r"(?i)(?P<prefix>.*/)*(?P<name>.+)-[v]{0,1}(?P<version>\d+\.\d+\.\d+)-.+").map_err(|err| {
-        Error::Release(format!(
-            "Failed constructing regex to parse S3 filenames: {}",
-            err
-        ))
-    })?;
+    let regex =
+        Regex::new(r"(?i)(?P<prefix>.*/)*(?P<name>.+)-[v]{0,1}(?P<version>\d+\.\d+\.\d+)-.+")
+            .map_err(|err| {
+                Error::Release(format!(
+                    "Failed constructing regex to parse S3 filenames: {}",
+                    err
+                ))
+            })?;
 
     // inspecting each XML element we populate our releases list
     let mut buf = Vec::new();
@@ -514,10 +518,7 @@ fn fetch_releases_from_s3(
                 // if we cannot decode a tag text we just ignore it
                 if let Ok(txt) = e.unescape_and_decode(&reader) {
                     match current_tag {
-                
-
                         Tag::Key => {
-
                             let p = PathBuf::from(&txt);
                             let exe_name = match p.file_name().map(|v| v.to_str()) {
                                 Some(Some(v)) => v,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ use std::io;
 use std::path;
 
 #[macro_use]
+extern crate log;
+
+#[macro_use]
 mod macros;
 pub mod backends;
 pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,10 @@ impl<'a> Extract<'a> {
             None => detect_archive(&self.source)?,
         };
 
-        debug!("Attempting to extract {:?} file from {:?}", file_to_extract, self.source);
+        debug!(
+            "Attempting to extract {:?} file from {:?}",
+            file_to_extract, self.source
+        );
 
         // We cannot use a feature flag in a match arm. To bypass this the code block is
         // isolated in a closure and called accordingly.
@@ -474,7 +477,7 @@ impl<'a> Extract<'a> {
                         .find(|e| {
                             let p = e.path();
                             debug!("Archive path: {:?}", p);
-                            p.ok().filter(|p| p == file_to_extract ).is_some()
+                            p.ok().filter(|p| p == file_to_extract).is_some()
                         })
                         .ok_or_else(|| {
                             Error::Update(format!(


### PR DESCRIPTION
Hey thanks for making this, i added an optional `v` to the version string for those of us that use `cargo-release` or `vX.X.X` tags, as well as a dependency on `log` and a couple of `debug!` entries to help with debugging behaviour (it'd definitely be useful to have more of these).