### PR TITLE
tempdir is deprecated; switch to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 serde_json = "1"
+tempfile = "3.1"
 tempdir = "0.3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ fn update() -> Result<(), Box<::std::error::Error>> {
 
 */
 
-pub use tempdir::TempDir;
+pub use tempfile::TempDir;
 
 #[cfg(feature = "compression-flate2")]
 use either::Either;
@@ -706,7 +706,7 @@ mod tests {
     #[cfg(feature = "archive-tar")]
     use tar;
     #[cfg(feature = "archive-zip")]
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     #[cfg(feature = "archive-zip")]
     use zip;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -194,7 +194,9 @@ pub trait ReleaseUpdate {
             bin_install_path.parent().map(PathBuf::from)
         }
         .ok_or_else(|| Error::Update("Failed to determine parent dir".into()))?;
-        let tmp_dir = tempdir::TempDir::new_in(&tmp_dir_parent, &format!("{}_download", bin_name))?;
+        let tmp_dir = tempfile::Builder::new()
+            .prefix(&format!("{}_download", bin_name))
+            .tempdir_in(tmp_dir_parent)?;
         let tmp_archive_path = tmp_dir.path().join(&target_asset.name);
         let mut tmp_archive = fs::File::create(&tmp_archive_path)?;
 


### PR DESCRIPTION
We're using `self_update` in our code (https://github.com/apollographql/apollo-cli) and got [this deprecation warning](https://github.com/apollographql/apollo-cli/issues/48). This PR swaps the deprecated `tempdir` for `tempfile`.

https://github.com/rust-lang-deprecated/tempdir/pull/46