### PR TITLE
S3: Support DigitalOcean Spaces as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn update() -> Result<(), Box<::std::error::Error>> {
 Run the above example to see `self_update` in action: `cargo run --example github --features "archive-tar compression-flate2"`.
 There's also an equivalent example for gitlab: `cargo run --example gitlab --features "archive-tar compression-flate2"`.
 
-Amazon S3 is also supported as the backend to check for new releases. Provided a `bucket_name`
+Amazon S3 and DigitalOcean Spaces are also supported through the `S3` backend to check for new releases. Provided a `bucket_name`
 and `asset_prefix` string, `self_update` will look up all matching files using the following format
 as a convention for the filenames: `[directory/]<asset name>-<semver>-<platform/target>.<extension>`.
 Leading directories will be stripped from the file name allowing the use of subdirectories in the S3 bucket,


### PR DESCRIPTION
The difference is just the URLs used to we just need a simple parameter to configure the end point.

Fixes #56.