### PR TITLE
S3: Add GCS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 ### Added
+- Add GCS support to S3 backend
 ### Changed
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn update() -> Result<(), Box<::std::error::Error>> {
 Run the above example to see `self_update` in action: `cargo run --example github --features "archive-tar compression-flate2"`.
 There's also an equivalent example for gitlab: `cargo run --example gitlab --features "archive-tar compression-flate2"`.
 
-Amazon S3 and DigitalOcean Spaces are also supported through the `S3` backend to check for new releases. Provided a `bucket_name`
+Amazon S3, Google GCS, and DigitalOcean Spaces are also supported through the `S3` backend to check for new releases. Provided a `bucket_name`
 and `asset_prefix` string, `self_update` will look up all matching files using the following format
 as a convention for the filenames: `[directory/]<asset name>-<semver>-<platform/target>.<extension>`.
 Leading directories will be stripped from the file name allowing the use of subdirectories in the S3 bucket,

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -20,10 +20,11 @@ const MAX_KEYS: u8 = 100;
 
 /// The service end point.
 ///
-/// Currently S3 and DigitalOcean Spaces supported.
+/// Currently S3, GCS, and DigitalOcean Spaces supported.
 #[derive(Clone, Copy, Debug)]
 pub enum EndPoint {
     S3,
+    GCS,
     DigitalOceanSpaces,
 }
 
@@ -83,11 +84,7 @@ impl ReleaseListBuilder {
             } else {
                 bail!(Error::Config, "`bucket_name` required")
             },
-            region: if let Some(ref region) = self.region {
-                region.to_owned()
-            } else {
-                bail!(Error::Config, "`region` required")
-            },
+            region: self.region.clone(),
             asset_prefix: self.asset_prefix.clone(),
             target: self.target.clone(),
         })
@@ -102,7 +99,7 @@ pub struct ReleaseList {
     bucket_name: String,
     asset_prefix: Option<String>,
     target: Option<String>,
-    region: String,
+    region: Option<String>,
 }
 
 impl ReleaseList {
@@ -137,7 +134,7 @@ impl ReleaseList {
     }
 }
 
-/// `github::Update` builder
+/// `s3::Update` builder
 ///
 /// Configure download and installation from
 /// `https://<bucket_name>.s3.<region>.amazonaws.com/<asset filename>`
@@ -195,7 +192,7 @@ impl UpdateBuilder {
         self
     }
 
-    /// Set the repo name, used to build a github api url
+    /// Set the repo name, used to build a s3 api url
     pub fn bucket_name(&mut self, name: &str) -> &mut Self {
         self.bucket_name = Some(name.to_owned());
         self
@@ -274,7 +271,7 @@ impl UpdateBuilder {
     /// The path provided should be:
     ///
     /// ```
-    /// # use self_update::backends::github::Update;
+    /// # use self_update::backends::s3::Update;
     /// # fn run() -> Result<(), Box<::std::error::Error>> {
     /// Update::configure()
     ///     .bin_path_in_archive("bin/myapp")
@@ -334,11 +331,7 @@ impl UpdateBuilder {
             } else {
                 bail!(Error::Config, "`bucket_name` required")
             },
-            region: if let Some(ref region) = self.region {
-                region.to_owned()
-            } else {
-                bail!(Error::Config, "`region` required")
-            },
+            region: self.region.clone(),
             asset_prefix: self.asset_prefix.clone(),
             target: self
                 .target
@@ -378,7 +371,7 @@ pub struct Update {
     bucket_name: String,
     asset_prefix: Option<String>,
     target: String,
-    region: String,
+    region: Option<String>,
     current_version: String,
     target_version: Option<String>,
     bin_name: String,
@@ -498,32 +491,43 @@ impl ReleaseUpdate for Update {
 fn fetch_releases_from_s3(
     end_point: EndPoint,
     bucket_name: &str,
-    region: &str,
+    region: &Option<String>,
     asset_prefix: &Option<String>,
 ) -> Result<Vec<Release>> {
     let prefix = match asset_prefix {
         Some(prefix) => format!("&prefix={}", prefix),
         None => "".to_string(),
     };
+
+    let download_base_url = match end_point {
+        EndPoint::S3 => {
+            let region = if let Some(region) = region {
+                region
+            } else {
+                bail!(Error::Config, "`region` required")
+            };
+            format!("https://{}.s3.{}.amazonaws.com/", bucket_name, region)
+        }
+        EndPoint::DigitalOceanSpaces => {
+            let region = if let Some(region) = region {
+                region
+            } else {
+                bail!(Error::Config, "`region` required")
+            };
+            format!("https://{}.{}.digitaloceanspaces.com/", bucket_name, region)
+        }
+        EndPoint::GCS => format!("https://storage.googleapis.com/{}/", bucket_name),
+    };
+
     let api_url = match end_point {
-        EndPoint::S3 => format!(
-            "https://{}.s3.amazonaws.com/?list-type=2&max-keys={}{}",
-            bucket_name, MAX_KEYS, prefix
+        EndPoint::S3 | EndPoint::DigitalOceanSpaces => format!(
+            "{}?list-type=2&max-keys={}{}",
+            download_base_url, MAX_KEYS, prefix
         ),
-        EndPoint::DigitalOceanSpaces => format!(
-            "https://{}.{}.digitaloceanspaces.com/?list-type=2&max-keys={}{}",
-            bucket_name, region, MAX_KEYS, prefix
-        ),
+        EndPoint::GCS => format!("{}?max-keys={}{}", download_base_url, MAX_KEYS, prefix),
     };
 
     debug!("using api url: {:?}", api_url);
-
-    let download_base_url = match end_point {
-        EndPoint::S3 => format!("https://{}.s3.{}.amazonaws.com/", bucket_name, region),
-        EndPoint::DigitalOceanSpaces => {
-            format!("https://{}.{}.digitaloceanspaces.com/", bucket_name, region,)
-        }
-    };
 
     let resp = reqwest::blocking::Client::new().get(&api_url).send()?;
     if !resp.status().is_success() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,18 +202,12 @@ impl Status {
 
     /// Returns `true` if `Status::UpToDate`
     pub fn uptodate(&self) -> bool {
-        match *self {
-            Status::UpToDate(_) => true,
-            _ => false,
-        }
+        matches!(*self, Status::UpToDate(_))
     }
 
     /// Returns `true` if `Status::Updated`
     pub fn updated(&self) -> bool {
-        match *self {
-            Status::Updated(_) => true,
-            _ => false,
-        }
+        matches!(*self, Status::Updated(_))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn update() -> Result<(), Box<::std::error::Error>> {
 Run the above example to see `self_update` in action: `cargo run --example github --features "archive-tar compression-flate2"`.
 There's also an equivalent example for gitlab: `cargo run --example gitlab --features "archive-tar compression-flate2"`.
 
-Amazon S3 and DigitalOcean Spaces are also supported through the `S3` backend to check for new releases. Provided a `bucket_name`
+Amazon S3, Google GCS, and DigitalOcean Spaces are also supported through the `S3` backend to check for new releases. Provided a `bucket_name`
 and `asset_prefix` string, `self_update` will look up all matching files using the following format
 as a convention for the filenames: `[directory/]<asset name>-<semver>-<platform/target>.<extension>`.
 Leading directories will be stripped from the file name allowing the use of subdirectories in the S3 bucket,

--- a/src/update.rs
+++ b/src/update.rs
@@ -34,10 +34,7 @@ impl UpdateStatus {
 
     /// Returns `true` if `Status::UpToDate`
     pub fn uptodate(&self) -> bool {
-        match *self {
-            UpdateStatus::UpToDate => true,
-            _ => false,
-        }
+        matches!(*self, UpdateStatus::UpToDate)
     }
 
     /// Returns `true` if `Status::Updated`


### PR DESCRIPTION
This PR relies on the work done to add Spaces (https://github.com/jaemk/self_update/pull/57) to add a GCS endpoint to the S3 backend. The main difference compared to S3/Spaces is that GCS doesn't need a region to build the URL, and the code will ignore the region if given.

Fixes #59 .