### PR TITLE
bump reqwest to 0.11 (tokio 1.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ rustls = ["reqwest/rustls-tls"]
 all-features = true
 
 [dependencies.reqwest]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["blocking", "json"]


### PR DESCRIPTION
the trivial part of the pending updates, #63 being the other one