### PR TITLE
Fix issues updating Windows binaries on non-C: drives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- Fix issues updating Windows binaries on non-`C:` drives.
 ### Removed
 
 ## [0.24.0]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,7 +559,10 @@ impl<'a> Move<'a> {
             }
             Some(temp) => {
                 if dest.exists() {
-                    fs::rename(dest, temp)?;
+                    // Copy the destination file rather than renaming it, so that
+                    // if it is a running executable the temp file can be removed
+                    // on Windows while the executable is running.
+                    fs::copy(dest, temp)?;
                     if let Err(e) = fs::rename(self.source, dest) {
                         fs::rename(temp, dest)?;
                         return Err(Error::from(e));

--- a/src/update.rs
+++ b/src/update.rs
@@ -185,12 +185,10 @@ pub trait ReleaseUpdate {
             confirm("Do you want to continue? [Y/n] ")?;
         }
 
-        let tmp_dir_parent = if cfg!(windows) {
-            env::var_os("TEMP").map(PathBuf::from)
-        } else {
-            bin_install_path.parent().map(PathBuf::from)
-        }
-        .ok_or_else(|| Error::Update("Failed to determine parent dir".into()))?;
+        let tmp_dir_parent = bin_install_path
+            .parent()
+            .map(PathBuf::from)
+            .ok_or_else(|| Error::Update("Failed to determine parent dir".into()))?;
         let tmp_dir = tempfile::Builder::new()
             .prefix(&format!("{}_download", bin_name))
             .tempdir_in(tmp_dir_parent)?;


### PR DESCRIPTION
Fixes https://github.com/jaemk/self_update/issues/67.

I'm not sure why `TEMP` is required on Windows, but it might've been to force the temp file to be cleaned up by the OS. The `tempfile` crate should have been doing this even outside the `TEMP` directory, but couldn't because the running executable was still referencing the temp file at the time that `tempfile::TempDir` was dropped. I've tested on Windows and this PR seems to fix those issues, and `fs::rename(self.source, dest);` still works when overwriting the file of the running executable.