### PR TITLE
Clean up dangling temporary directories on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- Clean up dangling temporary directories on Windows.
 ### Removed
 
 ## [0.25.0]


### PR DESCRIPTION
Easiest solution I can think of to avoid temporary directories building up as discussed in https://github.com/jaemk/self_update/pull/69. This creates a separate temporary directory just for the exe backup, which is manually removed on Windows the next time the updated exe is run. Could go in a patch release (last PR from me hopefully).

Backing up the exe to a separate temporary directory allows us to:
- check its contents before deleting, because it will always contain just the exe, not the download.
- have the other temporary directory for the zip download be automatically removed by the `tempfile` crate now that it isn't used to store the exe backup.