### PR TITLE
bump zip and quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ tempfile = "3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "0.11"
-zip = { version = "0.5", default-features = false, features = ["time"], optional = true }
+zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 hyper = "0.14"
 indicatif = "0.16"
-quick-xml = "0.20"
+quick-xml = "0.22"
 regex = "1"
 log = "0.4"
 


### PR DESCRIPTION
bumping zip also gets rid of the security advisory below and resolves #82

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 402 security advisories (from C:\Users\joeln\.cargo\advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (138 crate dependencies)
Crate:         time
Version:       0.1.44
Title:         Potential segfault in the time crate
Date:          2020-11-18
ID:            RUSTSEC-2020-0071
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:      Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── zip 0.5.13
    └── self_update 0.28.0

error: 1 vulnerability found!
```