### PR TITLE
Support for gitlab self hosted servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 ### Added
+- Support for self hosted gitlab servers
 ### Changed
 ### Removed
 

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -63,16 +63,16 @@ impl Release {
 /// `ReleaseList` Builder
 #[derive(Clone, Debug)]
 pub struct ReleaseListBuilder {
-    server: String,
+    host: String,
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
     auth_token: Option<String>,
 }
 impl ReleaseListBuilder {
-    /// Set the gitlab `server` url
-    pub fn use_server(&mut self, server: &str) -> &mut Self {
-        self.server = server.to_owned();
+    /// Set the gitlab `host` url
+    pub fn with_host(&mut self, host: &str) -> &mut Self {
+        self.host = host.to_owned();
         self
     }
 
@@ -108,7 +108,7 @@ impl ReleaseListBuilder {
     /// Verify builder args, returning a `ReleaseList`
     pub fn build(&self) -> Result<ReleaseList> {
         Ok(ReleaseList {
-            server: self.server.clone(),
+            host: self.host.clone(),
             repo_owner: if let Some(ref owner) = self.repo_owner {
                 owner.to_owned()
             } else {
@@ -129,7 +129,7 @@ impl ReleaseListBuilder {
 /// returning a `Vec` of available `Release`s
 #[derive(Clone, Debug)]
 pub struct ReleaseList {
-    server: String,
+    host: String,
     repo_owner: String,
     repo_name: String,
     target: Option<String>,
@@ -139,7 +139,7 @@ impl ReleaseList {
     /// Initialize a ReleaseListBuilder
     pub fn configure() -> ReleaseListBuilder {
         ReleaseListBuilder {
-            server: String::from("https://gitlab.com"),
+            host: String::from("https://gitlab.com"),
             repo_owner: None,
             repo_name: None,
             target: None,
@@ -153,7 +153,7 @@ impl ReleaseList {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
-            self.server, self.repo_owner, self.repo_name
+            self.host, self.repo_owner, self.repo_name
         );
         let releases = self.fetch_releases(&api_url)?;
         let releases = match self.target {
@@ -221,7 +221,7 @@ impl ReleaseList {
 /// `https://gitlab.com/api/v4/projects/<repo_owner>%2F<repo_name>/releases`
 #[derive(Debug)]
 pub struct UpdateBuilder {
-    server: String,
+    host: String,
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
@@ -244,9 +244,9 @@ impl UpdateBuilder {
         Default::default()
     }
 
-    /// Set the gitlab `server` url
-    pub fn use_server(&mut self, server: &str) -> &mut Self {
-        self.server = server.to_owned();
+    /// Set the gitlab `host` url
+    pub fn with_host(&mut self, host: &str) -> &mut Self {
+        self.host = host.to_owned();
         self
     }
 
@@ -392,7 +392,7 @@ impl UpdateBuilder {
         };
 
         Ok(Box::new(Update {
-            server: self.server.to_owned(),
+            host: self.host.to_owned(),
             repo_owner: if let Some(ref owner) = self.repo_owner {
                 owner.to_owned()
             } else {
@@ -438,7 +438,7 @@ impl UpdateBuilder {
 /// Updates to a specified or latest release distributed via Gitlab
 #[derive(Debug)]
 pub struct Update {
-    server: String,
+    host: String,
     repo_owner: String,
     repo_name: String,
     target: String,
@@ -466,7 +466,7 @@ impl ReleaseUpdate for Update {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
-            self.server, self.repo_owner, self.repo_name
+            self.host, self.repo_owner, self.repo_name
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
@@ -488,7 +488,7 @@ impl ReleaseUpdate for Update {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases/{}",
-            self.server, self.repo_owner, self.repo_name, ver
+            self.host, self.repo_owner, self.repo_name, ver
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
@@ -558,7 +558,7 @@ impl ReleaseUpdate for Update {
 impl Default for UpdateBuilder {
     fn default() -> Self {
         Self {
-            server: String::from("https://gitlab.com"),
+            host: String::from("https://gitlab.com"),
             repo_owner: None,
             repo_name: None,
             target: None,

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -63,12 +63,19 @@ impl Release {
 /// `ReleaseList` Builder
 #[derive(Clone, Debug)]
 pub struct ReleaseListBuilder {
+    server: String,
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
     auth_token: Option<String>,
 }
 impl ReleaseListBuilder {
+    /// Set the gitlab `server` url
+    pub fn use_server(&mut self, server: &str) -> &mut Self {
+        self.server = server.to_owned();
+        self
+    }
+
     /// Set the repo owner, used to build a gitlab api url
     pub fn repo_owner(&mut self, owner: &str) -> &mut Self {
         self.repo_owner = Some(owner.to_owned());
@@ -89,7 +96,7 @@ impl ReleaseListBuilder {
 
     /// Set the authorization token, used in requests to the gitlab api url
     ///
-    /// This is to support private repos where you need a GitHub auth token.
+    /// This is to support private repos where you need a Gitlab auth token.
     /// **Make sure not to bake the token into your app**; it is recommended
     /// you obtain it via another mechanism, such as environment variables
     /// or prompting the user for input
@@ -101,6 +108,7 @@ impl ReleaseListBuilder {
     /// Verify builder args, returning a `ReleaseList`
     pub fn build(&self) -> Result<ReleaseList> {
         Ok(ReleaseList {
+            server: self.server.clone(),
             repo_owner: if let Some(ref owner) = self.repo_owner {
                 owner.to_owned()
             } else {
@@ -117,10 +125,11 @@ impl ReleaseListBuilder {
     }
 }
 
-/// `ReleaseList` provides a builder api for querying a GitHub repo,
+/// `ReleaseList` provides a builder api for querying a Gitlab repo,
 /// returning a `Vec` of available `Release`s
 #[derive(Clone, Debug)]
 pub struct ReleaseList {
+    server: String,
     repo_owner: String,
     repo_name: String,
     target: Option<String>,
@@ -130,6 +139,7 @@ impl ReleaseList {
     /// Initialize a ReleaseListBuilder
     pub fn configure() -> ReleaseListBuilder {
         ReleaseListBuilder {
+            server: String::from("https://gitlab.com"),
             repo_owner: None,
             repo_name: None,
             target: None,
@@ -142,8 +152,8 @@ impl ReleaseList {
     pub fn fetch(self) -> Result<Vec<Release>> {
         set_ssl_vars!();
         let api_url = format!(
-            "https://gitlab.com/api/v4/projects/{}%2F{}/releases",
-            self.repo_owner, self.repo_name
+            "{}/api/v4/projects/{}%2F{}/releases",
+            self.server, self.repo_owner, self.repo_name
         );
         let releases = self.fetch_releases(&api_url)?;
         let releases = match self.target {
@@ -211,6 +221,7 @@ impl ReleaseList {
 /// `https://gitlab.com/api/v4/projects/<repo_owner>%2F<repo_name>/releases`
 #[derive(Debug)]
 pub struct UpdateBuilder {
+    server: String,
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
@@ -231,6 +242,12 @@ impl UpdateBuilder {
     /// Initialize a new builder
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Set the gitlab `server` url
+    pub fn use_server(&mut self, server: &str) -> &mut Self {
+        self.server = server.to_owned();
+        self
     }
 
     /// Set the repo owner, used to build a gitlab api url
@@ -354,7 +371,7 @@ impl UpdateBuilder {
 
     /// Set the authorization token, used in requests to the gitlab api url
     ///
-    /// This is to support private repos where you need a GitHub auth token.
+    /// This is to support private repos where you need a Gitlab auth token.
     /// **Make sure not to bake the token into your app**; it is recommended
     /// you obtain it via another mechanism, such as environment variables
     /// or prompting the user for input
@@ -375,6 +392,7 @@ impl UpdateBuilder {
         };
 
         Ok(Box::new(Update {
+            server: self.server.to_owned(),
             repo_owner: if let Some(ref owner) = self.repo_owner {
                 owner.to_owned()
             } else {
@@ -417,9 +435,10 @@ impl UpdateBuilder {
     }
 }
 
-/// Updates to a specified or latest release distributed via GitHub
+/// Updates to a specified or latest release distributed via Gitlab
 #[derive(Debug)]
 pub struct Update {
+    server: String,
     repo_owner: String,
     repo_name: String,
     target: String,
@@ -446,8 +465,8 @@ impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Release> {
         set_ssl_vars!();
         let api_url = format!(
-            "https://gitlab.com/api/v4/projects/{}%2F{}/releases",
-            self.repo_owner, self.repo_name
+            "{}/api/v4/projects/{}%2F{}/releases",
+            self.server, self.repo_owner, self.repo_name
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
@@ -468,8 +487,8 @@ impl ReleaseUpdate for Update {
     fn get_release_version(&self, ver: &str) -> Result<Release> {
         set_ssl_vars!();
         let api_url = format!(
-            "https://gitlab.com/api/v4/projects/{}%2F{}/releases/{}",
-            self.repo_owner, self.repo_name, ver
+            "{}/api/v4/projects/{}%2F{}/releases/{}",
+            self.server, self.repo_owner, self.repo_name, ver
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
@@ -539,6 +558,7 @@ impl ReleaseUpdate for Update {
 impl Default for UpdateBuilder {
     fn default() -> Self {
         Self {
+            server: String::from("https://gitlab.com"),
             repo_owner: None,
             repo_name: None,
             target: None,


### PR DESCRIPTION
Added possibility to use self hosted/in house Gitlab servers.
https://gitlab.com is  still  used by default. Unless specifically changed using the "use_server(server: &str)" methods.