### PR TITLE
bump quick-xml from 0.22 to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ either = { version = "1", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 hyper = "0.14"
 indicatif = "0.17"
-quick-xml = "0.22"
+quick-xml = "0.23"
 regex = "1"
 log = "0.4"
 


### PR DESCRIPTION
bumping to 0.23 takes care of this future-incompatibility warning.

The package `quick-xml v0.22.0` currently triggers the following future incompatibility lints:
> warning: trailing semicolon in macro used in expression position
>    --> /Users/joelnatividad/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-xml-0.22.0/src/events/attributes.rs:362:20
>     |
> 362 |                 }));
>     |                    ^
> ...
> 379 |             None => attr!(self.position..len),
>     |                     ------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `attr`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
>
> warning: trailing semicolon in macro used in expression position
>    --> /Users/joelnatividad/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-xml-0.22.0/src/events/attributes.rs:362:20
>     |
> 362 |                 }));
>     |                    ^
> ...
> 407 |             None => attr!(start_key..len),
>     |                     --------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `attr`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
>
> warning: trailing semicolon in macro used in expression position
>    --> /Users/joelnatividad/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-xml-0.22.0/src/events/attributes.rs:362:20
>     |
> 362 |                 }));
>     |                    ^
> ...
> 429 |                         attr!(start_key..end_key, i + 1..j)
>     |                         ----------------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `attr`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
>
> warning: trailing semicolon in macro used in expression position
>    --> /Users/joelnatividad/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-xml-0.22.0/src/events/attributes.rs:362:20
>     |
> 362 |                 }));
>     |                    ^
> ...
> 440 |                 attr!(start_key..end_key, i..j)
>     |                 ------------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `attr`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
>
> warning: trailing semicolon in macro used in expression position
>    --> /Users/joelnatividad/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-xml-0.22.0/src/events/attributes.rs:362:20
>     |
> 362 |                 }));
>     |                    ^
> ...
> 443 |             None => attr!(start_key..end_key),
>     |                     ------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `attr`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
>