### PR TITLE
Url encode repo owner in Gitlab backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,12 @@ indicatif = "0.17"
 quick-xml = "0.23"
 regex = "1"
 log = "0.4"
+urlencoding = "2.1"
 
 [features]
 default = ["reqwest/default-tls"]
 archive-zip = ["zip"]
-compression-zip-bzip2 = ["zip/bzip2"] #
+compression-zip-bzip2 = ["zip/bzip2"]     #
 compression-zip-deflate = ["zip/deflate"] #
 archive-tar = ["tar"]
 compression-flate2 = ["flate2", "either"] #

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -153,7 +153,9 @@ impl ReleaseList {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
-            self.host, self.repo_owner, self.repo_name
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            self.repo_name
         );
         let releases = self.fetch_releases(&api_url)?;
         let releases = match self.target {
@@ -466,7 +468,9 @@ impl ReleaseUpdate for Update {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
-            self.host, self.repo_owner, self.repo_name
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            self.repo_name
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
@@ -488,7 +492,10 @@ impl ReleaseUpdate for Update {
         set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases/{}",
-            self.host, self.repo_owner, self.repo_name, ver
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            self.repo_name,
+            ver
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)


### PR DESCRIPTION
If the repo is owned by a subgroup on Gitlab, repo_owner needs to be urlencoded in the API calls. Before this change you would have to change for example '/' to '%2F' to get this crate work do it's magic :)

I have tested this locally and it works like a charm.