### PR TITLE
Bugfix: GitLab auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- Bugfix: use appropriate auth headers for each backend (fix gitlab private repo updates)
 ### Removed
 
 ## [0.36.0]

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -479,7 +479,7 @@ impl ReleaseUpdate for Update {
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
-            .headers(api_headers(&self.auth_token)?)
+            .headers(self.api_headers(&self.auth_token)?)
             .send()?;
         if !resp.status().is_success() {
             bail!(
@@ -501,7 +501,7 @@ impl ReleaseUpdate for Update {
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
-            .headers(api_headers(&self.auth_token)?)
+            .headers(self.api_headers(&self.auth_token)?)
             .send()?;
         if !resp.status().is_success() {
             bail!(
@@ -561,6 +561,10 @@ impl ReleaseUpdate for Update {
 
     fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()
+    }
+
+    fn api_headers(&self, auth_token: &Option<String>) -> Result<header::HeaderMap> {
+        api_headers(auth_token)
     }
 }
 

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -1,6 +1,7 @@
 /*!
 GitHub releases
 */
+use hyper::HeaderMap;
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
@@ -584,6 +585,10 @@ impl ReleaseUpdate for Update {
 
     fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()
+    }
+
+    fn api_headers(&self, auth_token: &Option<String>) -> Result<HeaderMap> {
+        api_headers(auth_token)
     }
 }
 

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -474,7 +474,7 @@ impl ReleaseUpdate for Update {
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
-            .headers(api_headers(&self.auth_token)?)
+            .headers(self.api_headers(&self.auth_token)?)
             .send()?;
         if !resp.status().is_success() {
             bail!(
@@ -499,7 +499,7 @@ impl ReleaseUpdate for Update {
         );
         let resp = reqwest::blocking::Client::new()
             .get(&api_url)
-            .headers(api_headers(&self.auth_token)?)
+            .headers(self.api_headers(&self.auth_token)?)
             .send()?;
         if !resp.status().is_success() {
             bail!(
@@ -559,6 +559,10 @@ impl ReleaseUpdate for Update {
 
     fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()
+    }
+
+    fn api_headers(&self, auth_token: &Option<String>) -> Result<header::HeaderMap> {
+        api_headers(auth_token)
     }
 }
 


### PR DESCRIPTION
Fixes the download of private GitLab artifacts to also use Bearer token, and also makes headers on artifact downloads configurable per-backend in general.