### PR TITLE
Use `self-replace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- Use `self-replace` to replace current executable
 ### Removed
 
 ## [0.37.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ quick-xml = "0.23"
 regex = "1"
 log = "0.4"
 urlencoding = "2.1"
+self-replace = "1"
 
 [features]
 default = ["reqwest/default-tls"]


### PR DESCRIPTION
This PR makes `self_update` use [`self-replace`] to replace the downloaded executable file. Replacing a running file on windows is no simple task, and in my tests `self_update` at least sometimes failed to replace the `.exe` file.

`self-replace` is useful on other platforms, too, e.g. it properly copies the file permissions.

Closes #109.

[`self-replace`]: https://docs.rs/self-replace