### PR TITLE
Change `reqwest` dependency against `isahc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,21 @@ tar = { version = "0.4", optional = true }
 semver = "1.0"
 zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
-hyper = "0.14"
 indicatif = "0.17"
 quick-xml = "0.23"
 regex = "1"
 log = "0.4"
 urlencoding = "2.1"
 self-replace = "1"
+isahc = { version = "1.7", default-features = false, features = ["json", "text-decoding"] }
 
 [features]
-default = ["reqwest/default-tls"]
+default = []
 archive-zip = ["zip"]
 compression-zip-bzip2 = ["zip/bzip2"]     #
 compression-zip-deflate = ["zip/deflate"] #
 archive-tar = ["tar"]
 compression-flate2 = ["flate2", "either"] #
-rustls = ["reqwest/rustls-tls"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -4,7 +4,9 @@ gitea releases
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
+use isahc::config::{Configurable, RedirectPolicy};
+use isahc::http::header;
+use isahc::{HttpClient, ReadResponseExt, Request};
 
 use crate::backends::find_rel_next_link;
 use crate::{
@@ -172,10 +174,14 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
-            .get(url)
-            .headers(api_headers(&self.auth_token)?)
-            .send()?;
+        let mut req = Request::builder()
+            .uri(url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,
@@ -184,7 +190,6 @@ impl ReleaseList {
                 url
             )
         }
-        let headers = resp.headers().clone();
 
         let releases = resp.json::<serde_json::Value>()?;
         let releases = releases
@@ -197,7 +202,7 @@ impl ReleaseList {
 
         // handle paged responses containing `Link` header:
         // `Link: <https://gitea.com/api/v4/projects/13083/releases?id=13083&page=2&per_page=20>; rel="next"`
-        let links = headers.get_all(reqwest::header::LINK);
+        let links = resp.headers().get_all(header::LINK);
 
         let next_link = links
             .iter()
@@ -477,10 +482,15 @@ impl ReleaseUpdate for Update {
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
+
+        let mut req = Request::builder()
+            .uri(&api_url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,
@@ -499,10 +509,15 @@ impl ReleaseUpdate for Update {
             "{}/api/v1/repos/{}/{}/releases/{}",
             self.host, self.repo_owner, self.repo_name, ver
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
+
+        let mut req = Request::builder()
+            .uri(&api_url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -4,7 +4,9 @@ Gitlab releases
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
+use isahc::config::{Configurable, RedirectPolicy};
+use isahc::http::header;
+use isahc::{HttpClient, ReadResponseExt, Request};
 
 use crate::backends::find_rel_next_link;
 use crate::{
@@ -169,10 +171,14 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
-            .get(url)
-            .headers(api_headers(&self.auth_token)?)
-            .send()?;
+        let mut req = Request::builder()
+            .uri(url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,
@@ -181,8 +187,6 @@ impl ReleaseList {
                 url
             )
         }
-        let headers = resp.headers().clone();
-
         let releases = resp.json::<serde_json::Value>()?;
         let releases = releases
             .as_array()
@@ -194,7 +198,7 @@ impl ReleaseList {
 
         // handle paged responses containing `Link` header:
         // `Link: <https://gitlab.com/api/v4/projects/13083/releases?id=13083&page=2&per_page=20>; rel="next"`
-        let links = headers.get_all(reqwest::header::LINK);
+        let links = resp.headers().get_all(header::LINK);
 
         let next_link = links
             .iter()
@@ -472,10 +476,15 @@ impl ReleaseUpdate for Update {
             urlencoding::encode(&self.repo_owner),
             self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
+
+        let mut req = Request::builder()
+            .uri(&api_url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,
@@ -497,10 +506,15 @@ impl ReleaseUpdate for Update {
             self.repo_name,
             ver
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
+
+        let mut req = Request::builder()
+            .uri(&api_url)
+            .redirect_policy(RedirectPolicy::Limit(10));
+        req.headers_mut()
+            .unwrap()
+            .extend(api_headers(&self.auth_token)?);
+        let mut resp = HttpClient::new()?.send(req.body(())?)?;
+
         if !resp.status().is_success() {
             bail!(
                 Error::Network,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,9 +17,10 @@ pub enum Error {
     #[cfg(feature = "archive-zip")]
     Zip(ZipError),
     Json(serde_json::Error),
-    Reqwest(reqwest::Error),
     SemVer(semver::Error),
     ArchiveNotEnabled(String),
+    Isahc(isahc::Error),
+    Http(isahc::http::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -32,11 +33,12 @@ impl std::fmt::Display for Error {
             Config(ref s) => write!(f, "ConfigError: {}", s),
             Io(ref e) => write!(f, "IoError: {}", e),
             Json(ref e) => write!(f, "JsonError: {}", e),
-            Reqwest(ref e) => write!(f, "ReqwestError: {}", e),
             SemVer(ref e) => write!(f, "SemVerError: {}", e),
             #[cfg(feature = "archive-zip")]
             Zip(ref e) => write!(f, "ZipError: {}", e),
             ArchiveNotEnabled(ref s) => write!(f, "ArchiveNotEnabled: Archive extension '{}' not supported, please enable 'archive-{}' feature!", s, s),
+            Isahc(ref e) => write!(f, "HTTP configuration error: {}", e),
+            Http(ref e) => write!(f, "HTTP error: {}", e),
         }
     }
 }
@@ -51,7 +53,6 @@ impl std::error::Error for Error {
         Some(match *self {
             Io(ref e) => e,
             Json(ref e) => e,
-            Reqwest(ref e) => e,
             SemVer(ref e) => e,
             _ => return None,
         })
@@ -62,7 +63,6 @@ impl std::error::Error for Error {
         Some(match *self {
             Io(ref e) => e,
             Json(ref e) => e,
-            Reqwest(ref e) => e,
             SemVer(ref e) => e,
             _ => return None,
         })
@@ -81,12 +81,6 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Error {
-        Error::Reqwest(e)
-    }
-}
-
 impl From<semver::Error> for Error {
     fn from(e: semver::Error) -> Error {
         Error::SemVer(e)
@@ -97,5 +91,17 @@ impl From<semver::Error> for Error {
 impl From<ZipError> for Error {
     fn from(e: ZipError) -> Error {
         Error::Zip(e)
+    }
+}
+
+impl From<isahc::Error> for Error {
+    fn from(value: isahc::Error) -> Self {
+        Self::Isahc(value)
+    }
+}
+
+impl From<isahc::http::Error> for Error {
+    fn from(value: isahc::http::Error) -> Self {
+        Self::Http(value)
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,7 @@
-use reqwest::{self, header};
 use std::fs;
 use std::path::PathBuf;
+
+use isahc::http::header;
 
 use crate::{confirm, errors::*, version, Download, Extract, Status};
 


### PR DESCRIPTION
This PR removes `reqwest`, and its transitive dependencies like `tokio`, and uses `isahc` instead. The latter library uses `curl` as HTTP client. `libcurl` should be installed by default on all current Windows and MacOS installations, and most likely by all serious Linux distros, too.

`libcurl` is only loaded at runtime instead of being a hard dependecy. This way, if `libcurl` is not installed, the program will still run just fine, but the self update will fail.

This changes makes the `github` example much smaller:

```text
1808048 github.master
1476544 github.patch
-331504 bytes or -18%
```

```text
$ size github.master github.patch
   text    data    bss      dec  filename
1738914   52288    529  1791731  github.master
1406298   40616   1840  1448754  github.patch
-332616  -11672  +1311  -342977
```