### PR TITLE
Change `reqwest` dependency against `ureq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,23 @@ tar = { version = "0.4", optional = true }
 semver = "1.0"
 zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
-hyper = "0.14"
 indicatif = "0.17"
 quick-xml = "0.23"
 regex = "1"
 log = "0.4"
 urlencoding = "2.1"
 self-replace = "1"
+ureq = { version = "2.7", default-features = false, features = ["gzip", "json", "native-tls"] }
+native-tls = "0.2"
+once_cell = "1"
 
 [features]
-default = ["reqwest/default-tls"]
+default = []
 archive-zip = ["zip"]
 compression-zip-bzip2 = ["zip/bzip2"]     #
 compression-zip-deflate = ["zip/deflate"] #
 archive-tar = ["tar"]
 compression-flate2 = ["flate2", "either"] #
-rustls = ["reqwest/rustls-tls"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -4,9 +4,8 @@ gitea releases
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
-
 use crate::backends::find_rel_next_link;
+use crate::update::api_headers;
 use crate::{
     errors::*,
     get_target,
@@ -154,7 +153,6 @@ impl ReleaseList {
     /// Retrieve a list of `Release`s.
     /// If specified, filter for those containing a specified `target`
     pub fn fetch(self) -> Result<Vec<Release>> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
@@ -172,21 +170,17 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
-            .get(url)
-            .headers(api_headers(&self.auth_token)?)
-            .send()?;
-        if !resp.status().is_success() {
-            bail!(
-                Error::Network,
-                "api request failed with status: {:?} - for: {:?}",
-                resp.status(),
-                url
-            )
-        }
-        let headers = resp.headers().clone();
+        let resp = crate::get(url, &api_headers(self.auth_token.as_deref())?)?;
 
-        let releases = resp.json::<serde_json::Value>()?;
+        // handle paged responses containing `Link` header:
+        // `Link: <https://gitea.com/api/v4/projects/13083/releases?id=13083&page=2&per_page=20>; rel="next"`
+        let next_link = resp
+            .all("link")
+            .into_iter()
+            .find_map(|link| find_rel_next_link(link))
+            .map(|s| s.to_owned());
+
+        let releases = resp.into_json::<serde_json::Value>()?;
         let releases = releases
             .as_array()
             .ok_or_else(|| format_err!(Error::Release, "No releases found"))?;
@@ -195,25 +189,10 @@ impl ReleaseList {
             .map(Release::from_release_gitea)
             .collect::<Result<Vec<Release>>>()?;
 
-        // handle paged responses containing `Link` header:
-        // `Link: <https://gitea.com/api/v4/projects/13083/releases?id=13083&page=2&per_page=20>; rel="next"`
-        let links = headers.get_all(reqwest::header::LINK);
-
-        let next_link = links
-            .iter()
-            .filter_map(|link| {
-                if let Ok(link) = link.to_str() {
-                    find_rel_next_link(link)
-                } else {
-                    None
-                }
-            })
-            .next();
-
         Ok(match next_link {
             None => releases,
             Some(link) => {
-                releases.extend(self.fetch_releases(link)?);
+                releases.extend(self.fetch_releases(&link)?);
                 releases
             }
         })
@@ -472,46 +451,24 @@ impl Update {
 
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
-        if !resp.status().is_success() {
-            bail!(
-                Error::Network,
-                "api request failed with status: {:?} - for: {:?}",
-                resp.status(),
-                api_url
-            )
-        }
-        let json = resp.json::<serde_json::Value>()?;
+
+        let req = crate::get(&api_url, &api_headers(self.auth_token.as_deref())?)?;
+        let json = req.into_json::<serde_json::Value>()?;
         Release::from_release_gitea(&json[0])
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases/{}",
             self.host, self.repo_owner, self.repo_name, ver
         );
-        let resp = reqwest::blocking::Client::new()
-            .get(&api_url)
-            .headers(self.api_headers(&self.auth_token)?)
-            .send()?;
-        if !resp.status().is_success() {
-            bail!(
-                Error::Network,
-                "api request failed with status: {:?} - for: {:?}",
-                resp.status(),
-                api_url
-            )
-        }
-        let json = resp.json::<serde_json::Value>()?;
+
+        let req = crate::get(&api_url, &api_headers(self.auth_token.as_deref())?)?;
+        let json = req.into_json::<serde_json::Value>()?;
         Release::from_release_gitea(&json)
     }
 
@@ -562,10 +519,6 @@ impl ReleaseUpdate for Update {
     fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()
     }
-
-    fn api_headers(&self, auth_token: &Option<String>) -> Result<header::HeaderMap> {
-        api_headers(auth_token)
-    }
 }
 
 impl Default for UpdateBuilder {
@@ -588,25 +541,4 @@ impl Default for UpdateBuilder {
             auth_token: None,
         }
     }
-}
-
-fn api_headers(auth_token: &Option<String>) -> Result<header::HeaderMap> {
-    let mut headers = header::HeaderMap::new();
-    headers.insert(
-        header::USER_AGENT,
-        "rust-reqwest/self-update"
-            .parse()
-            .expect("gitea invalid user-agent"),
-    );
-
-    if let Some(token) = auth_token {
-        headers.insert(
-            header::AUTHORIZATION,
-            format!("token {}", token)
-                .parse()
-                .map_err(|err| Error::Config(format!("Failed to parse auth token: {}", err)))?,
-        );
-    };
-
-    Ok(headers)
 }

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1,6 +1,14 @@
 /*!
 Amazon S3 releases
 */
+use std::cmp::Ordering;
+use std::env::{self, consts::EXE_SUFFIX};
+use std::path::{Path, PathBuf};
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use regex::Regex;
+
 use crate::{
     errors::*,
     get_target,
@@ -8,12 +16,6 @@ use crate::{
     version::bump_is_greater,
     DEFAULT_PROGRESS_CHARS, DEFAULT_PROGRESS_TEMPLATE,
 };
-use quick_xml::events::Event;
-use quick_xml::Reader;
-use regex::Regex;
-use std::cmp::Ordering;
-use std::env::{self, consts::EXE_SUFFIX};
-use std::path::{Path, PathBuf};
 
 /// Maximum number of items to retrieve from S3 API
 const MAX_KEYS: u8 = 100;
@@ -537,17 +539,7 @@ fn fetch_releases_from_s3(
 
     debug!("using api url: {:?}", api_url);
 
-    let resp = reqwest::blocking::Client::new().get(&api_url).send()?;
-    if !resp.status().is_success() {
-        bail!(
-            Error::Network,
-            "S3 API request failed with status: {:?} - for: {:?}",
-            resp.status(),
-            api_url
-        )
-    }
-
-    let body = resp.text()?;
+    let body = crate::get(&api_url, &[])?.into_string()?;
     let mut reader = Reader::from_str(&body);
     reader.trim_text(true);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,21 +8,6 @@ macro_rules! cargo_crate_version {
     };
 }
 
-/// Set ssl cert env. vars to make sure openssl can find required files
-macro_rules! set_ssl_vars {
-    () => {
-        #[cfg(target_os = "linux")]
-        {
-            if ::std::env::var_os("SSL_CERT_FILE").is_none() {
-                ::std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
-            }
-            if ::std::env::var_os("SSL_CERT_DIR").is_none() {
-                ::std::env::set_var("SSL_CERT_DIR", "/etc/ssl/certs");
-            }
-        }
-    };
-}
-
 /// Helper to `print!` and immediately `flush` `stdout`
 macro_rules! print_flush {
     ($literal:expr) => {


### PR DESCRIPTION
This PR removes `reqwest`, and its transitive dependencies like `tokio`, and uses `ureq` instead. The latter library uses `curl` as HTTP client. `libcurl` should be installed by default on all current Windows and MacOS installations, and most likely by all serious Linux distros, too.

`libcurl` is only loaded at runtime instead of being a hard dependecy. This way, if `libcurl` is not installed, the program will still run just fine, but the self update will fail.

This changes makes the `github` example much smaller:

```text
1808048 github.master
1127536 github.patch
-680512 bytes or -38%
```

```text
$ size github.master github.patch
   text    data  bss      dec  filename
1738914   52288  529  1791731  github.master
1078768   31784  465  1111017  github.patch
-660146  -20504  -64  -680714
```