### PR TITLE
Add `Release::asset_for` ability to find asset by current `OS` and `ARCH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- `Release::asset_for` now searches for current `OS` and `ARCH` inside `asset.name` if `target` failed to match
 ### Removed
 
 ## [0.39.0]

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,5 @@
 use reqwest::{self, header};
+use std::env::consts::{ARCH, OS};
 use std::fs;
 use std::path::PathBuf;
 
@@ -62,11 +63,12 @@ impl Release {
             .iter()
             .find(|asset| {
                 asset.name.contains(target)
-                    && if let Some(i) = identifier {
-                        asset.name.contains(i)
-                    } else {
-                        true
-                    }
+                    || (asset.name.contains(OS) && asset.name.contains(ARCH))
+                        && if let Some(i) = identifier {
+                            asset.name.contains(i)
+                        } else {
+                            true
+                        }
             })
             .cloned()
     }


### PR DESCRIPTION
This PR allows to find resources with these example names:
* foo-linux-x86_64.bar
* foo-macos-aarch64.bar
* foo-windows-x86_64.bar