### PR TITLE
Bump reqwest & hyper and allow http2 negotiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ tar = { version = "0.4", optional = true }
 semver = "1.0"
 zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
-hyper = "0.14"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2"] }
+hyper = "1"
 indicatif = "0.17"
 quick-xml = "0.23"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "self_update"
-version = "0.39.0"
+name        = "self_update"
+version     = "0.39.0"
 description = "Self updates for standalone executables"
-repository = "https://github.com/jaemk/self_update"
-keywords = ["update", "upgrade", "download", "release"]
-categories = ["command-line-utilities"]
-license = "MIT"
-readme = "README.md"
-authors = ["James Kominick <james@kominick.com>"]
-exclude = ["/ci/*", ".travis.yml", "appveyor.yml"]
-edition = "2018"
-rust = "1.64"
+repository  = "https://github.com/jaemk/self_update"
+keywords    = ["update", "upgrade", "download", "release"]
+categories  = ["command-line-utilities"]
+license     = "MIT"
+readme      = "README.md"
+authors     = ["James Kominick <james@kominick.com>"]
+exclude     = ["/ci/*", ".travis.yml", "appveyor.yml"]
+edition     = "2018"
+rust        = "1.64"
 
 [dependencies]
 serde_json = "1"
@@ -18,9 +18,16 @@ tempfile = "3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "1.0"
-zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
+zip = { version = "0.6", default-features = false, features = [
+    "time",
+], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
+    "json",
+    "rustls-tls",
+    "http2",
+] }
 hyper = "1"
 indicatif = "0.17"
 quick-xml = "0.23"
@@ -31,14 +38,14 @@ self-replace = "1"
 zipsign-api = { version = "0.1.0-a.3", default-features = false, optional = true }
 
 [features]
-default = ["reqwest/default-tls"]
-archive-zip = ["zip", "zipsign-api?/verify-zip"]
-compression-zip-bzip2 = ["archive-zip", "zip/bzip2"]
+default                 = ["reqwest/default-tls"]
+archive-zip             = ["zip", "zipsign-api?/verify-zip"]
+compression-zip-bzip2   = ["archive-zip", "zip/bzip2"]
 compression-zip-deflate = ["archive-zip", "zip/deflate"]
-archive-tar = ["tar", "zipsign-api?/verify-tar"]
-compression-flate2 = ["archive-tar", "flate2", "either"]
-rustls = ["reqwest/rustls-tls"]
-signatures = ["dep:zipsign-api"]
+archive-tar             = ["tar", "zipsign-api?/verify-tar"]
+compression-flate2      = ["archive-tar", "flate2", "either"]
+rustls                  = ["reqwest/rustls-tls"]
+signatures              = ["dep:zipsign-api"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name        = "self_update"
-version     = "0.39.0"
+name = "self_update"
+version = "0.39.0"
 description = "Self updates for standalone executables"
-repository  = "https://github.com/jaemk/self_update"
-keywords    = ["update", "upgrade", "download", "release"]
-categories  = ["command-line-utilities"]
-license     = "MIT"
-readme      = "README.md"
-authors     = ["James Kominick <james@kominick.com>"]
-exclude     = ["/ci/*", ".travis.yml", "appveyor.yml"]
-edition     = "2018"
-rust        = "1.64"
+repository = "https://github.com/jaemk/self_update"
+keywords = ["update", "upgrade", "download", "release"]
+categories = ["command-line-utilities"]
+license = "MIT"
+readme = "README.md"
+authors = ["James Kominick <james@kominick.com>"]
+exclude = ["/ci/*", ".travis.yml", "appveyor.yml"]
+edition = "2018"
+rust = "1.64"
 
 [dependencies]
 serde_json = "1"
@@ -18,16 +18,9 @@ tempfile = "3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "1.0"
-zip = { version = "0.6", default-features = false, features = [
-    "time",
-], optional = true }
+zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.12", default-features = false, features = [
-    "blocking",
-    "json",
-    "rustls-tls",
-    "http2",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2"] }
 hyper = "1"
 indicatif = "0.17"
 quick-xml = "0.23"
@@ -38,14 +31,14 @@ self-replace = "1"
 zipsign-api = { version = "0.1.0-a.3", default-features = false, optional = true }
 
 [features]
-default                 = ["reqwest/default-tls"]
-archive-zip             = ["zip", "zipsign-api?/verify-zip"]
-compression-zip-bzip2   = ["archive-zip", "zip/bzip2"]
+default = ["reqwest/default-tls"]
+archive-zip = ["zip", "zipsign-api?/verify-zip"]
+compression-zip-bzip2 = ["archive-zip", "zip/bzip2"]
 compression-zip-deflate = ["archive-zip", "zip/deflate"]
-archive-tar             = ["tar", "zipsign-api?/verify-tar"]
-compression-flate2      = ["archive-tar", "flate2", "either"]
-rustls                  = ["reqwest/rustls-tls"]
-signatures              = ["dep:zipsign-api"]
+archive-tar = ["tar", "zipsign-api?/verify-tar"]
+compression-flate2 = ["archive-tar", "flate2", "either"]
+rustls = ["reqwest/rustls-tls"]
+signatures = ["dep:zipsign-api"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -172,7 +172,11 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
             .send()?;
@@ -496,7 +500,11 @@ impl ReleaseUpdate for Update {
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
             .send()?;
@@ -518,7 +526,11 @@ impl ReleaseUpdate for Update {
             "{}/api/v1/repos/{}/{}/releases/{}",
             self.host, self.repo_owner, self.repo_name, ver
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
             .send()?;

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -174,7 +174,11 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
             .send()?;
@@ -511,7 +515,11 @@ impl ReleaseUpdate for Update {
             self.repo_owner,
             self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(api_headers(&self.auth_token)?)
             .send()?;
@@ -538,7 +546,11 @@ impl ReleaseUpdate for Update {
             self.repo_name,
             ver
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(api_headers(&self.auth_token)?)
             .send()?;

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -169,7 +169,11 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
             .send()?;
@@ -491,7 +495,11 @@ impl ReleaseUpdate for Update {
             urlencoding::encode(&self.repo_owner),
             self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
             .send()?;
@@ -516,7 +524,11 @@ impl ReleaseUpdate for Update {
             self.repo_name,
             ver
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
             .send()?;

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -563,7 +563,11 @@ fn fetch_releases_from_s3(
 
     debug!("using api url: {:?}", api_url);
 
-    let resp = reqwest::blocking::Client::new().get(&api_url).send()?;
+    let client = reqwest::blocking::ClientBuilder::new()
+        .use_rustls_tls()
+        .http2_adaptive_window(true)
+        .build()?;
+    let resp = client.get(&api_url).send()?;
     if !resp.status().is_success() {
         bail!(
             Error::Network,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,10 +681,11 @@ impl Download {
         }
 
         set_ssl_vars!();
-        let resp = reqwest::blocking::Client::new()
-            .get(&self.url)
-            .headers(headers)
-            .send()?;
+        let client = reqwest::blocking::ClientBuilder::new()
+            .use_rustls_tls()
+            .http2_adaptive_window(true)
+            .build()?;
+        let resp = client.get(&self.url).headers(headers).send()?;
         let size = resp
             .headers()
             .get(reqwest::header::CONTENT_LENGTH)


### PR DESCRIPTION
Somewhat duplicative of #124, but also went ahead to add the ability to transparently negotiate upgrading to an HTTP2 connection, which all the backends support.