### PR TITLE
Support variable substitutions in `bin_path_in_archive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Release::asset_for` now searches for current `OS` and `ARCH` inside `asset.name` if `target` failed to match
 - Update `reqwest` to `0.12.0`
 - Update `hyper` to `1.2.0`
+- Support variable substitutions in `bin_path_in_archive` at runtime
 ### Removed
 
 ## [0.39.0]

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -232,7 +232,7 @@ pub struct UpdateBuilder {
     target: Option<String>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
-    bin_path_in_archive: Option<PathBuf>,
+    bin_path_in_archive: Option<String>,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -300,10 +300,10 @@ impl UpdateBuilder {
     /// (see `std::env::consts::EXE_SUFFIX`) to the name if it's missing.
     pub fn bin_name(&mut self, name: &str) -> &mut Self {
         let raw_bin_name = format!("{}{}", name.trim_end_matches(EXE_SUFFIX), EXE_SUFFIX);
-        self.bin_name = Some(raw_bin_name.clone());
         if self.bin_path_in_archive.is_none() {
-            self.bin_path_in_archive = Some(PathBuf::from(raw_bin_name));
+            self.bin_path_in_archive = Some(raw_bin_name.clone());
         }
+        self.bin_name = Some(raw_bin_name);
         self
     }
 
@@ -321,13 +321,20 @@ impl UpdateBuilder {
     /// the path to the binary (from the root of the tarball) is not equal to just
     /// the `bin_name`.
     ///
+    /// This also supports variable paths:
+    /// - `{{ bin }}` is replaced with the value of `bin_name`
+    /// - `{{ target }}` is replaced with the value of `target`
+    /// - `{{ version }}` is replaced with the value of `target_version` if set,
+    /// otherwise the value of the latest available release version is used.
+    ///
     /// # Example
     ///
-    /// For a tarball `myapp.tar.gz` with the contents:
+    /// For a `myapp` binary with `windows` target and latest release version `1.2.3`,
+    /// the tarball `myapp.tar.gz` has the contents:
     ///
     /// ```shell
     /// myapp.tar/
-    ///  |------- bin/
+    ///  |------- windows-1.2.3-bin/
     ///  |         |--- myapp  # <-- executable
     /// ```
     ///
@@ -335,15 +342,15 @@ impl UpdateBuilder {
     ///
     /// ```
     /// # use self_update::backends::gitea::Update;
-    /// # fn run() -> Result<(), Box< dyn ::std::error::Error>> {
+    /// # fn run() -> Result<(), Box<::std::error::Error>> {
     /// Update::configure()
-    ///     .bin_path_in_archive("bin/myapp")
+    ///     .bin_path_in_archive("{{ target }}-{{ version }}-bin/{{ bin }}")
     /// #   .build()?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn bin_path_in_archive(&mut self, bin_path: &str) -> &mut Self {
-        self.bin_path_in_archive = Some(PathBuf::from(bin_path));
+        self.bin_path_in_archive = Some(bin_path.to_owned());
         self
     }
 
@@ -438,8 +445,8 @@ impl UpdateBuilder {
                 bail!(Error::Config, "`bin_name` required")
             },
             bin_install_path,
-            bin_path_in_archive: if let Some(ref path) = self.bin_path_in_archive {
-                path.to_owned()
+            bin_path_in_archive: if let Some(ref bin_path) = self.bin_path_in_archive {
+                bin_path.to_owned()
             } else {
                 bail!(Error::Config, "`bin_path_in_archive` required")
             },
@@ -472,7 +479,7 @@ pub struct Update {
     target_version: Option<String>,
     bin_name: String,
     bin_install_path: PathBuf,
-    bin_path_in_archive: PathBuf,
+    bin_path_in_archive: String,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -554,7 +561,7 @@ impl ReleaseUpdate for Update {
         self.bin_install_path.clone()
     }
 
-    fn bin_path_in_archive(&self) -> PathBuf {
+    fn bin_path_in_archive(&self) -> String {
         self.bin_path_in_archive.clone()
     }
 

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -229,7 +229,7 @@ pub struct UpdateBuilder {
     target: Option<String>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
-    bin_path_in_archive: Option<PathBuf>,
+    bin_path_in_archive: Option<String>,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -297,10 +297,10 @@ impl UpdateBuilder {
     /// (see `std::env::consts::EXE_SUFFIX`) to the name if it's missing.
     pub fn bin_name(&mut self, name: &str) -> &mut Self {
         let raw_bin_name = format!("{}{}", name.trim_end_matches(EXE_SUFFIX), EXE_SUFFIX);
-        self.bin_name = Some(raw_bin_name.clone());
         if self.bin_path_in_archive.is_none() {
-            self.bin_path_in_archive = Some(PathBuf::from(raw_bin_name));
+            self.bin_path_in_archive = Some(raw_bin_name.to_owned());
         }
+        self.bin_name = Some(raw_bin_name);
         self
     }
 
@@ -318,13 +318,20 @@ impl UpdateBuilder {
     /// the path to the binary (from the root of the tarball) is not equal to just
     /// the `bin_name`.
     ///
+    /// This also supports variable paths:
+    /// - `{{ bin }}` is replaced with the value of `bin_name`
+    /// - `{{ target }}` is replaced with the value of `target`
+    /// - `{{ version }}` is replaced with the value of `target_version` if set,
+    /// otherwise the value of the latest available release version is used.
+    ///
     /// # Example
     ///
-    /// For a tarball `myapp.tar.gz` with the contents:
+    /// For a `myapp` binary with `windows` target and latest release version `1.2.3`,
+    /// the tarball `myapp.tar.gz` has the contents:
     ///
     /// ```shell
     /// myapp.tar/
-    ///  |------- bin/
+    ///  |------- windows-1.2.3-bin/
     ///  |         |--- myapp  # <-- executable
     /// ```
     ///
@@ -332,15 +339,15 @@ impl UpdateBuilder {
     ///
     /// ```
     /// # use self_update::backends::gitlab::Update;
-    /// # fn run() -> Result<(), Box< dyn ::std::error::Error>> {
+    /// # fn run() -> Result<(), Box<::std::error::Error>> {
     /// Update::configure()
-    ///     .bin_path_in_archive("bin/myapp")
+    ///     .bin_path_in_archive("{{ target }}-{{ version }}-bin/{{ bin }}")
     /// #   .build()?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn bin_path_in_archive(&mut self, bin_path: &str) -> &mut Self {
-        self.bin_path_in_archive = Some(PathBuf::from(bin_path));
+        self.bin_path_in_archive = Some(bin_path.to_owned());
         self
     }
 
@@ -431,8 +438,8 @@ impl UpdateBuilder {
                 bail!(Error::Config, "`bin_name` required")
             },
             bin_install_path,
-            bin_path_in_archive: if let Some(ref path) = self.bin_path_in_archive {
-                path.to_owned()
+            bin_path_in_archive: if let Some(ref bin_path) = self.bin_path_in_archive {
+                bin_path.to_owned()
             } else {
                 bail!(Error::Config, "`bin_path_in_archive` required")
             },
@@ -465,7 +472,7 @@ pub struct Update {
     target_version: Option<String>,
     bin_name: String,
     bin_install_path: PathBuf,
-    bin_path_in_archive: PathBuf,
+    bin_path_in_archive: String,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -552,7 +559,7 @@ impl ReleaseUpdate for Update {
         self.bin_install_path.clone()
     }
 
-    fn bin_path_in_archive(&self) -> PathBuf {
+    fn bin_path_in_archive(&self) -> String {
         self.bin_path_in_archive.clone()
     }
 

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -144,7 +144,7 @@ pub struct UpdateBuilder {
     region: Option<String>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
-    bin_path_in_archive: Option<PathBuf>,
+    bin_path_in_archive: Option<String>,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -241,10 +241,10 @@ impl UpdateBuilder {
     /// Set the exe's name. Also sets `bin_path_in_archive` if it hasn't already been set.
     pub fn bin_name(&mut self, name: &str) -> &mut Self {
         let raw_bin_name = format!("{}{}", name.trim_end_matches(EXE_SUFFIX), EXE_SUFFIX);
-        self.bin_name = Some(raw_bin_name.clone());
         if self.bin_path_in_archive.is_none() {
-            self.bin_path_in_archive = Some(PathBuf::from(raw_bin_name));
+            self.bin_path_in_archive = Some(raw_bin_name.to_owned());
         }
+        self.bin_name = Some(raw_bin_name);
         self
     }
 
@@ -262,13 +262,20 @@ impl UpdateBuilder {
     /// the path to the binary (from the root of the tarball) is not equal to just
     /// the `bin_name`.
     ///
+    /// This also supports variable paths:
+    /// - `{{ bin }}` is replaced with the value of `bin_name`
+    /// - `{{ target }}` is replaced with the value of `target`
+    /// - `{{ version }}` is replaced with the value of `target_version` if set,
+    /// otherwise the value of the latest available release version is used.
+    ///
     /// # Example
     ///
-    /// For a tarball `myapp.tar.gz` with the contents:
+    /// For a `myapp` binary with `windows` target and latest release version `1.2.3`,
+    /// the tarball `myapp.tar.gz` has the contents:
     ///
     /// ```shell
     /// myapp.tar/
-    ///  |------- bin/
+    ///  |------- windows-1.2.3-bin/
     ///  |         |--- myapp  # <-- executable
     /// ```
     ///
@@ -278,13 +285,13 @@ impl UpdateBuilder {
     /// # use self_update::backends::s3::Update;
     /// # fn run() -> Result<(), Box<::std::error::Error>> {
     /// Update::configure()
-    ///     .bin_path_in_archive("bin/myapp")
+    ///     .bin_path_in_archive("{{ target }}-{{ version }}-bin/{{ bin }}")
     /// #   .build()?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn bin_path_in_archive(&mut self, bin_path: &str) -> &mut Self {
-        self.bin_path_in_archive = Some(PathBuf::from(bin_path));
+        self.bin_path_in_archive = Some(bin_path.to_owned());
         self
     }
 
@@ -366,8 +373,8 @@ impl UpdateBuilder {
                 bail!(Error::Config, "`bin_name` required")
             },
             bin_install_path,
-            bin_path_in_archive: if let Some(ref path) = self.bin_path_in_archive {
-                path.to_owned()
+            bin_path_in_archive: if let Some(ref bin_path) = self.bin_path_in_archive {
+                bin_path.to_owned()
             } else {
                 bail!(Error::Config, "`bin_path_in_archive` required")
             },
@@ -401,7 +408,7 @@ pub struct Update {
     target_version: Option<String>,
     bin_name: String,
     bin_install_path: PathBuf,
-    bin_path_in_archive: PathBuf,
+    bin_path_in_archive: String,
     show_download_progress: bool,
     show_output: bool,
     no_confirm: bool,
@@ -487,7 +494,7 @@ impl ReleaseUpdate for Update {
         self.bin_install_path.clone()
     }
 
-    fn bin_path_in_archive(&self) -> PathBuf {
+    fn bin_path_in_archive(&self) -> String {
         self.bin_path_in_archive.clone()
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -246,6 +246,15 @@ pub trait ReleaseUpdate {
         print_flush(show_output, "Extracting archive... ")?;
 
         let bin_path_str = Cow::Owned(self.bin_path_in_archive());
+
+        /// Substitute the `var` variable in a string with the given `val` value.
+        ///
+        /// Variable format: `{{ var }}`
+        fn substitute<'a: 'b, 'b>(str: &'a str, var: &str, val: &str) -> Cow<'b, str> {
+            let format = format!(r"\{{\{{[[:space:]]*{}[[:space:]]*\}}\}}", var);
+            Regex::new(&format).unwrap().replace_all(str, val)
+        }
+
         let bin_path_str = substitute(&bin_path_str, "version", &release.version);
         let bin_path_str = substitute(&bin_path_str, "target", &target);
         let bin_path_str = substitute(&bin_path_str, "bin", &bin_name);
@@ -263,14 +272,6 @@ pub trait ReleaseUpdate {
 
         Ok(UpdateStatus::Updated(release))
     }
-}
-
-/// Substitute the `var` variable in a string with the given `val` value.
-///
-/// Variable format: `{{ var }}`
-fn substitute<'a: 'b, 'b>(str: &'a str, var: &str, val: &str) -> Cow<'b, str> {
-    let format = format!(r"\{{\{{[[:space:]]*{}[[:space:]]*\}}\}}", var);
-    Regex::new(&format).unwrap().replace_all(str, val)
 }
 
 // Print out message based on provided flag and flush the output buffer

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,6 @@
+use regex::Regex;
 use reqwest::{self, header};
+use std::borrow::Cow;
 use std::env::consts::{ARCH, OS};
 use std::fs;
 use std::path::PathBuf;
@@ -103,7 +105,7 @@ pub trait ReleaseUpdate {
     fn bin_install_path(&self) -> PathBuf;
 
     /// Path of the binary to be extracted from release package
-    fn bin_path_in_archive(&self) -> PathBuf;
+    fn bin_path_in_archive(&self) -> String;
 
     /// Flag indicating if progress information shall be output when downloading a release
     fn show_download_progress(&self) -> bool;
@@ -242,10 +244,16 @@ pub trait ReleaseUpdate {
         verify_signature(&tmp_archive_path, self.verifying_keys())?;
 
         print_flush(show_output, "Extracting archive... ")?;
-        let bin_path_in_archive = self.bin_path_in_archive();
+
+        let bin_path_str = Cow::Owned(self.bin_path_in_archive());
+        let bin_path_str = substitute(&bin_path_str, "version", &release.version);
+        let bin_path_str = substitute(&bin_path_str, "target", &target);
+        let bin_path_str = substitute(&bin_path_str, "bin", &bin_name);
+        let bin_path_str = bin_path_str.as_ref();
+
         Extract::from_source(&tmp_archive_path)
-            .extract_file(tmp_archive_dir.path(), &bin_path_in_archive)?;
-        let new_exe = tmp_archive_dir.path().join(&bin_path_in_archive);
+            .extract_file(tmp_archive_dir.path(), bin_path_str)?;
+        let new_exe = tmp_archive_dir.path().join(bin_path_str);
 
         println(show_output, "Done");
 
@@ -255,6 +263,14 @@ pub trait ReleaseUpdate {
 
         Ok(UpdateStatus::Updated(release))
     }
+}
+
+/// Substitute the `var` variable in a string with the given `val` value.
+///
+/// Variable format: `{{ var }}`
+fn substitute<'a: 'b, 'b>(str: &'a str, var: &str, val: &str) -> Cow<'b, str> {
+    let format = format!(r"\{{\{{[[:space:]]*{}[[:space:]]*\}}\}}", var);
+    Regex::new(&format).unwrap().replace_all(str, val)
 }
 
 // Print out message based on provided flag and flush the output buffer


### PR DESCRIPTION
This fixes #122 by allowing `bin_path_in_archive` to refer to variables that are only available at runtime, especially the release version, which may not be known when getting the latest release without additional queries. It uses `{{ var }}` syntax and supports `bin`, `target` and `version`.

### Example:
```shell
myapp.tar/
 |------- windows-1.2.3-bin/
 |         |--- myapp  # <-- executable
```
Use `"{{ target }}-{{ version }}-bin/{{ bin }}"` for `bin_path_in_archive`.

### Note:
The regex that matches the syntax accepts zero or more ASCII whitespace characters around the `var`. Hence both `{{var}}` and `{{ var    }}` would work.

