### PR TITLE
Replace zip with zip_next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Release::asset_for` now searches for current `OS` and `ARCH` inside `asset.name` if `target` failed to match
 - Update `reqwest` to `0.12.0`
 - Update `hyper` to `1.2.0`
+- Replace `zip` with `zip_next`
 ### Removed
 
 ## [0.39.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = ["James Kominick <james@kominick.com>"]
 exclude = ["/ci/*", ".travis.yml", "appveyor.yml"]
 edition = "2018"
-rust = "1.64"
+rust-version = "1.67"
 
 [dependencies]
 serde_json = "1"
@@ -18,7 +18,7 @@ tempfile = "3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "1.0"
-zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
+zip_next = { version = "1.0", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
 hyper = "1"
@@ -32,9 +32,9 @@ zipsign-api = { version = "0.1.0-a.3", default-features = false, optional = true
 
 [features]
 default = ["reqwest/default-tls"]
-archive-zip = ["zip", "zipsign-api?/verify-zip"]
-compression-zip-bzip2 = ["archive-zip", "zip/bzip2"]
-compression-zip-deflate = ["archive-zip", "zip/deflate"]
+archive-zip = ["zip_next", "zipsign-api?/verify-zip"]
+compression-zip-bzip2 = ["archive-zip", "zip_next/bzip2"]
+compression-zip-deflate = ["archive-zip", "zip_next/deflate"]
 archive-tar = ["tar", "zipsign-api?/verify-tar"]
 compression-flate2 = ["archive-tar", "flate2", "either"]
 rustls = ["reqwest/rustls-tls"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ which runs something roughly equivalent to:
 ```rust
 use self_update::cargo_crate_version;
 
-fn update() -> Result<(), Box<::std::error::Error>> {
+fn update() -> Result<(), Box<dyn ::std::error::Error>> {
     let status = self_update::backends::github::Update::configure()
         .repo_owner("jaemk")
         .repo_name("self_update")
@@ -70,7 +70,7 @@ and any file not matching the format, or not matching the provided prefix string
 ```rust
 use self_update::cargo_crate_version;
 
-fn update() -> Result<(), Box<::std::error::Error>> {
+fn update() -> Result<(), Box<dyn ::std::error::Error>> {
     let status = self_update::backends::s3::Update::configure()
         .bucket_name("self_update_releases")
         .asset_prefix("something/self_update")

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -4,7 +4,7 @@ gitea releases
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
+use reqwest::header;
 
 use crate::backends::find_rel_next_link;
 use crate::{

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -5,7 +5,7 @@ use hyper::HeaderMap;
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
+use reqwest::header;
 
 use crate::backends::find_rel_next_link;
 use crate::{
@@ -348,7 +348,7 @@ impl UpdateBuilder {
     ///
     /// ```
     /// # use self_update::backends::github::Update;
-    /// # fn run() -> Result<(), Box<::std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn ::std::error::Error>> {
     /// Update::configure()
     ///     .bin_path_in_archive("bin/myapp")
     /// #   .build()?;

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -4,7 +4,7 @@ Gitlab releases
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
 
-use reqwest::{self, header};
+use reqwest::header;
 
 use crate::backends::find_rel_next_link;
 use crate::{
@@ -72,7 +72,7 @@ pub struct ReleaseListBuilder {
 impl ReleaseListBuilder {
     /// Set the gitlab `host` url
     pub fn with_host(&mut self, host: &str) -> &mut Self {
-        self.host = host.to_owned();
+        host.clone_into(&mut self.host);
         self
     }
 
@@ -250,7 +250,7 @@ impl UpdateBuilder {
 
     /// Set the gitlab `host` url
     pub fn with_host(&mut self, host: &str) -> &mut Self {
-        self.host = host.to_owned();
+        host.clone_into(&mut self.host);
         self
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@ Error type, conversions, and macros
 
 */
 #[cfg(feature = "archive-zip")]
-use zip::result::ZipError;
+use zip_next::result::ZipError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -48,7 +48,7 @@ impl std::fmt::Display for Error {
                 write!(f, "No signature verification implemented for {:?} files", kind)
             }
             #[cfg(feature = "signatures")]
-            Signature(ref e) => write!(f, "SignatureError: {}", e),
+            Signature(ref e) => write!(f, "SignatureError: {:?}", e),
             #[cfg(feature = "signatures")]
             NonUTF8 => write!(f, "Cannot verify signature of a file with a non-UTF-8 name"),
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,4 @@
-use reqwest::{self, header};
+use reqwest::header;
 use std::env::consts::{ARCH, OS};
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
The `zip` crate hasn't been updated in almost a year, and it has bugs which can cause a panic when trying to open an invalid ZIP file, or an encrypted one without the password. This PR updates `self_update` to instead use the `zip_next` crate, a fork I actively maintain. It also fixes warnings from newer versions of Clippy.