### PR TITLE
skip `sha` (`sha1`, `sha256`, `sha512`) checksum files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 ### Changed
+- skip `sha` (`sha1`, `sha256`, `sha512`) checksum files when determining the release asset 
 ### Removed
 
 ## [0.40.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [unreleased]
 ### Added
+- add `UpdateBuilder::asset_match_fn` to enable custom logic for release asset matching
 ### Changed
-- skip `sha` (`sha1`, `sha256`, `sha512`) checksum files when determining the release asset 
 ### Removed
 
 ## [0.40.0]

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -14,6 +14,7 @@ use crate::{
     update::{Release, ReleaseAsset, ReleaseUpdate},
     DEFAULT_PROGRESS_CHARS, DEFAULT_PROGRESS_TEMPLATE,
 };
+use crate::update::AssetMatchFn;
 
 impl ReleaseAsset {
     /// Parse a release-asset json object
@@ -232,6 +233,7 @@ pub struct UpdateBuilder {
     repo_name: Option<String>,
     target: Option<String>,
     identifier: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
     bin_path_in_archive: Option<String>,
@@ -304,6 +306,14 @@ impl UpdateBuilder {
     /// If unspecified, the first asset matching the target will be chosen
     pub fn identifier(&mut self, identifier: &str) -> &mut Self {
         self.identifier = Some(identifier.to_owned());
+        self
+    }
+
+    /// Set the function to match assets
+    ///
+    /// If unspecified, the first asset matching the target will be chosen
+    pub fn asset_match_fn(&mut self, asset_match_fn: AssetMatchFn) -> &mut Self {
+        self.asset_match_fn = Some(asset_match_fn);
         self
     }
 
@@ -448,6 +458,7 @@ impl UpdateBuilder {
                 .map(|t| t.to_owned())
                 .unwrap_or_else(|| get_target().to_owned()),
             identifier: self.identifier.clone(),
+            asset_match_fn: self.asset_match_fn.clone(),
             bin_name: if let Some(ref name) = self.bin_name {
                 name.to_owned()
             } else {
@@ -485,6 +496,7 @@ pub struct Update {
     repo_name: String,
     target: String,
     identifier: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     current_version: String,
     target_version: Option<String>,
     bin_name: String,
@@ -577,6 +589,10 @@ impl ReleaseUpdate for Update {
         self.identifier.clone()
     }
 
+    fn asset_match_fn(&self) -> Option<AssetMatchFn> {
+        self.asset_match_fn.clone()
+    }
+
     fn bin_name(&self) -> String {
         self.bin_name.clone()
     }
@@ -630,6 +646,7 @@ impl Default for UpdateBuilder {
             repo_name: None,
             target: None,
             identifier: None,
+            asset_match_fn: None,
             bin_name: None,
             bin_install_path: None,
             bin_path_in_archive: None,

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -13,6 +13,7 @@ use crate::{
     update::{Release, ReleaseAsset, ReleaseUpdate},
     DEFAULT_PROGRESS_CHARS, DEFAULT_PROGRESS_TEMPLATE,
 };
+use crate::update::AssetMatchFn;
 
 impl ReleaseAsset {
     /// Parse a release-asset json object
@@ -227,6 +228,7 @@ pub struct UpdateBuilder {
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
     bin_path_in_archive: Option<String>,
@@ -288,6 +290,14 @@ impl UpdateBuilder {
     /// If unspecified, the build target of the crate will be used
     pub fn target(&mut self, target: &str) -> &mut Self {
         self.target = Some(target.to_owned());
+        self
+    }
+
+    /// Set the function to match assets
+    ///
+    /// If unspecified, the first asset matching the target will be chosen
+    pub fn asset_match_fn(&mut self, asset_match_fn: AssetMatchFn) -> &mut Self {
+        self.asset_match_fn = Some(asset_match_fn);
         self
     }
 
@@ -432,6 +442,7 @@ impl UpdateBuilder {
                 .as_ref()
                 .map(|t| t.to_owned())
                 .unwrap_or_else(|| get_target().to_owned()),
+            asset_match_fn: self.asset_match_fn.clone(),
             bin_name: if let Some(ref name) = self.bin_name {
                 name.to_owned()
             } else {
@@ -470,6 +481,7 @@ pub struct Update {
     target: String,
     current_version: String,
     target_version: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     bin_name: String,
     bin_install_path: PathBuf,
     bin_path_in_archive: String,
@@ -551,6 +563,10 @@ impl ReleaseUpdate for Update {
         self.target_version.clone()
     }
 
+    fn asset_match_fn(&self) -> Option<AssetMatchFn> {
+        self.asset_match_fn.clone()
+    }
+
     fn bin_name(&self) -> String {
         self.bin_name.clone()
     }
@@ -604,6 +620,7 @@ impl Default for UpdateBuilder {
             repo_owner: None,
             repo_name: None,
             target: None,
+            asset_match_fn: None,
             bin_name: None,
             bin_install_path: None,
             bin_path_in_archive: None,

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use std::cmp::Ordering;
 use std::env::{self, consts::EXE_SUFFIX};
 use std::path::{Path, PathBuf};
+use crate::update::AssetMatchFn;
 
 /// Maximum number of items to retrieve from S3 API
 const MAX_KEYS: u8 = 100;
@@ -142,6 +143,7 @@ pub struct UpdateBuilder {
     asset_prefix: Option<String>,
     target: Option<String>,
     region: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
     bin_path_in_archive: Option<String>,
@@ -165,6 +167,7 @@ impl Default for UpdateBuilder {
             asset_prefix: None,
             target: None,
             region: None,
+            asset_match_fn: None,
             bin_name: None,
             bin_install_path: None,
             bin_path_in_archive: None,
@@ -367,6 +370,7 @@ impl UpdateBuilder {
                 .as_ref()
                 .map(|t| t.to_owned())
                 .unwrap_or_else(|| get_target().to_owned()),
+            asset_match_fn: self.asset_match_fn.clone(),
             bin_name: if let Some(ref name) = self.bin_name {
                 name.to_owned()
             } else {
@@ -406,6 +410,7 @@ pub struct Update {
     region: Option<String>,
     current_version: String,
     target_version: Option<String>,
+    asset_match_fn: Option<AssetMatchFn>,
     bin_name: String,
     bin_install_path: PathBuf,
     bin_path_in_archive: String,
@@ -484,6 +489,10 @@ impl ReleaseUpdate for Update {
 
     fn target_version(&self) -> Option<String> {
         self.target_version.clone()
+    }
+
+    fn asset_match_fn(&self) -> Option<AssetMatchFn> {
+        self.asset_match_fn.clone()
     }
 
     fn bin_name(&self) -> String {

--- a/src/update.rs
+++ b/src/update.rs
@@ -64,6 +64,12 @@ impl Release {
         self.assets
             .iter()
             .find(|asset| {
+                // Skip .sha(1|256|512) checksum files
+                let extension = asset.name.split('.').last().unwrap_or_default();
+                if extension.starts_with("sha") {
+                    return false;
+                }
+
                 asset.name.contains(target)
                     || (asset.name.contains(OS) && asset.name.contains(ARCH))
                         && if let Some(i) = identifier {


### PR DESCRIPTION
Skip `sha` (`sha1`, `sha256`, `sha512`) checksum files when determining the release asset.  Many projects (e.g. https://github.com/BurntSushi/ripgrep/releases, https://github.com/theseus-rs/rsql/releases, etc) include hash files with their releases, this change ignores the `.sha*` hash files when attempting to find the release archive.