### PR TITLE
update to zip 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3"
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "1.0"
-zip = { version = "0.6", default-features = false, features = ["time"], optional = true }
+zip = { version = "2", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
 hyper = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1085,7 +1085,7 @@ mod tests {
             #[cfg(feature = "archive-zip")]
             ArchiveKind::Zip => {
                 let mut zip = zip::ZipWriter::new(archive_file);
-                let options = zip::write::FileOptions::default()
+                let options = zip::write::SimpleFileOptions::default()
                     .compression_method(zip::CompressionMethod::Stored);
                 zip.start_file("temp.txt", options)
                     .expect("failed starting zip file");


### PR DESCRIPTION
zip 2.x (formerly zip-next - see https://github.com/jaemk/self_update/pull/128) is now the latest, maintained zip crate

cc @Pr0methean