### PR TITLE
feat: ✨ search new release

### DIFF
--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::version::bump_is_greater;
 use crate::{
     errors::*,
     get_target,
@@ -230,6 +231,7 @@ pub struct UpdateBuilder {
     repo_owner: Option<String>,
     repo_name: Option<String>,
     target: Option<String>,
+    identifier: Option<String>,
     bin_name: Option<String>,
     bin_install_path: Option<PathBuf>,
     bin_path_in_archive: Option<String>,
@@ -291,6 +293,14 @@ impl UpdateBuilder {
     /// If unspecified, the build target of the crate will be used
     pub fn target(&mut self, target: &str) -> &mut Self {
         self.target = Some(target.to_owned());
+        self
+    }
+
+    /// Set the identifiable token for the asset in case of multiple compatible assets
+    ///
+    /// If unspecified, the first asset matching the target will be chosen
+    pub fn identifier(&mut self, identifier: &str) -> &mut Self {
+        self.identifier = Some(identifier.to_owned());
         self
     }
 
@@ -439,6 +449,7 @@ impl UpdateBuilder {
                 .as_ref()
                 .map(|t| t.to_owned())
                 .unwrap_or_else(|| get_target().to_owned()),
+            identifier: self.identifier.clone(),
             bin_name: if let Some(ref name) = self.bin_name {
                 name.to_owned()
             } else {
@@ -475,6 +486,7 @@ pub struct Update {
     repo_owner: String,
     repo_name: String,
     target: String,
+    identifier: Option<String>,
     current_version: String,
     target_version: Option<String>,
     bin_name: String,
@@ -519,10 +531,45 @@ impl ReleaseUpdate for Update {
         Release::from_release_gitea(&json[0])
     }
 
+    fn get_latest_releases(&self, current_version: &str) -> Result<Vec<Release>> {
+        set_ssl_vars!();
+        let api_url = format!(
+            "{}/api/v1/repos/{}/{}/releases",
+            self.host, self.repo_owner, self.repo_name
+        );
+        let resp = reqwest::blocking::Client::new()
+            .get(&api_url)
+            .headers(self.api_headers(&self.auth_token)?)
+            .send()?;
+        if !resp.status().is_success() {
+            bail!(
+                Error::Network,
+                "api request failed with status: {:?} - for: {:?}",
+                resp.status(),
+                api_url
+            )
+        }
+
+        let json = resp.json::<serde_json::Value>()?;
+        json.as_array()
+            .ok_or_else(|| format_err!(Error::Release, "No releases found"))
+            .and_then(|releases| {
+                releases
+                    .iter()
+                    .map(Release::from_release_gitea)
+                    .filter(|r| {
+                        r.as_ref().map_or(false, |r| {
+                            bump_is_greater(current_version, &r.version).unwrap_or(false)
+                        })
+                    })
+                    .collect::<Result<Vec<Release>>>()
+            })
+    }
+
     fn get_release_version(&self, ver: &str) -> Result<Release> {
         set_ssl_vars!();
         let api_url = format!(
-            "{}/api/v1/repos/{}/{}/releases/{}",
+            "{}/api/v1/repos/{}/{}/releases/tags/{}",
             self.host, self.repo_owner, self.repo_name, ver
         );
         let resp = reqwest::blocking::Client::new()
@@ -551,6 +598,10 @@ impl ReleaseUpdate for Update {
 
     fn target_version(&self) -> Option<String> {
         self.target_version.clone()
+    }
+
+    fn identifier(&self) -> Option<String> {
+        self.identifier.clone()
     }
 
     fn bin_name(&self) -> String {
@@ -606,6 +657,7 @@ impl Default for UpdateBuilder {
             repo_owner: None,
             repo_name: None,
             target: None,
+            identifier: None,
             bin_name: None,
             bin_install_path: None,
             bin_path_in_archive: None,

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::version::bump_is_greater;
 use crate::{
     errors::*,
     get_target,
@@ -532,6 +533,45 @@ impl ReleaseUpdate for Update {
         }
         let json = resp.json::<serde_json::Value>()?;
         Release::from_release(&json)
+    }
+
+    fn get_latest_releases(&self, current_version: &str) -> Result<Vec<Release>> {
+        set_ssl_vars!();
+        let api_url = format!(
+            "{}/repos/{}/{}/releases",
+            self.custom_url
+                .as_ref()
+                .unwrap_or(&"https://api.github.com".to_string()),
+            self.repo_owner,
+            self.repo_name
+        );
+        let resp = reqwest::blocking::Client::new()
+            .get(&api_url)
+            .headers(api_headers(&self.auth_token)?)
+            .send()?;
+        if !resp.status().is_success() {
+            bail!(
+                Error::Network,
+                "api request failed with status: {:?} - for: {:?}",
+                resp.status(),
+                api_url
+            )
+        }
+
+        let json = resp.json::<serde_json::Value>()?;
+        json.as_array()
+            .ok_or_else(|| format_err!(Error::Release, "No releases found"))
+            .and_then(|releases| {
+                releases
+                    .iter()
+                    .map(Release::from_release)
+                    .filter(|r| {
+                        r.as_ref().map_or(false, |r| {
+                            bump_is_greater(current_version, &r.version).unwrap_or(false)
+                        })
+                    })
+                    .collect::<Result<Vec<Release>>>()
+            })
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::version::bump_is_greater;
 use crate::{
     errors::*,
     get_target,
@@ -512,6 +513,43 @@ impl ReleaseUpdate for Update {
         }
         let json = resp.json::<serde_json::Value>()?;
         Release::from_release_gitlab(&json[0])
+    }
+
+    fn get_latest_releases(&self, current_version: &str) -> Result<Vec<Release>> {
+        set_ssl_vars!();
+        let api_url = format!(
+            "{}/api/v4/projects/{}%2F{}/releases",
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            self.repo_name
+        );
+        let resp = reqwest::blocking::Client::new()
+            .get(&api_url)
+            .headers(self.api_headers(&self.auth_token)?)
+            .send()?;
+        if !resp.status().is_success() {
+            bail!(
+                Error::Network,
+                "api request failed with status: {:?} - for: {:?}",
+                resp.status(),
+                api_url
+            )
+        }
+
+        let json = resp.json::<serde_json::Value>()?;
+        json.as_array()
+            .ok_or_else(|| format_err!(Error::Release, "No releases found"))
+            .and_then(|releases| {
+                releases
+                    .iter()
+                    .map(Release::from_release_gitlab)
+                    .filter(|r| {
+                        r.as_ref().map_or(false, |r| {
+                            bump_is_greater(current_version, &r.version).unwrap_or(false)
+                        })
+                    })
+                    .collect::<Result<Vec<Release>>>()
+            })
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {


### PR DESCRIPTION
Hi,

I would like to propose this pull request.

Modifications are :

- `identifier`: Add identifier for gitea to filter the assets
- add missing /tags in the API to select the release by tags (and not by an unknown id)
- add notion of prerelease
- change how to get the version to update by getting latest versions (greater than the current version) and filter on compatible version. The goal is the possibility to have two stable version in parallel or one stable version and a prerelease version.
