### PR TITLE
Set `per_page` parameter in the GitHub Releases List API to the 100 (maximum possible value) to limit number of API requests

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -177,6 +177,7 @@ impl ReleaseList {
         let resp = reqwest::blocking::Client::new()
             .get(url)
             .headers(api_headers(&self.auth_token)?)
+            .query(&[("per_page", "100")])
             .send()?;
         if !resp.status().is_success() {
             bail!(


### PR DESCRIPTION
Fixes https://github.com/jaemk/self_update/issues/101

In https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases--parameters GitHub API provides a `per_page` query parameter to limit number of entries in every page of the releases API. It's 30 by default, and max number is 100. 
In this PR I set it to the 100 to limit number of API fetches. 

See my comment here https://github.com/aptos-labs/aptos-core/issues/6411#issuecomment-2525104504 as an example of why it's needed. 