### PR TITLE
Bump zip 2 to 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = ["James Kominick <james@kominick.com>"]
 exclude = ["/ci/*", ".travis.yml", "appveyor.yml"]
 edition = "2018"
-rust = "1.64"
+rust-version = "1.64"
 
 [dependencies]
 serde_json = "1"


### PR DESCRIPTION
also changed `rust` keyword to `rust-version` in package section of Cargo.toml