### PR TITLE
fix: reqwest TLS backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tar = { version = "0.4", optional = true }
 semver = "1.0"
 zip = { version = "2", default-features = false, features = ["time"], optional = true }
 either = { version = "1", optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "http2"] }
 hyper = "1"
 indicatif = "0.17"
 quick-xml = "0.37"

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::client;
 use crate::version::bump_is_greater;
 use crate::{
     errors::*,
@@ -155,7 +156,6 @@ impl ReleaseList {
     /// Retrieve a list of `Release`s.
     /// If specified, filter for those containing a specified `target`
     pub fn fetch(self) -> Result<Vec<Release>> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
@@ -173,10 +173,7 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
@@ -514,15 +511,11 @@ impl Update {
 
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
             self.host, self.repo_owner, self.repo_name
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
@@ -575,15 +568,11 @@ impl ReleaseUpdate for Update {
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases/tags/{}",
             self.host, self.repo_owner, self.repo_name, ver
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::client;
 use crate::version::bump_is_greater;
 use crate::{
     errors::*,
@@ -154,7 +155,6 @@ impl ReleaseList {
     /// Retrieve a list of `Release`s.
     /// If specified, filter for those containing a specified `target`
     pub fn fetch(self) -> Result<Vec<Release>> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/repos/{}/{}/releases",
             self.custom_url
@@ -175,10 +175,7 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
@@ -515,7 +512,6 @@ impl Update {
 
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/repos/{}/{}/releases/latest",
             self.custom_url
@@ -524,10 +520,7 @@ impl ReleaseUpdate for Update {
             self.repo_owner,
             self.repo_name
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(api_headers(&self.auth_token)?)
@@ -584,7 +577,6 @@ impl ReleaseUpdate for Update {
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/repos/{}/{}/releases/tags/{}",
             self.custom_url
@@ -594,10 +586,7 @@ impl ReleaseUpdate for Update {
             self.repo_name,
             ver
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(api_headers(&self.auth_token)?)

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use reqwest::{self, header};
 
 use crate::backends::find_rel_next_link;
+use crate::client;
 use crate::version::bump_is_greater;
 use crate::{
     errors::*,
@@ -151,7 +152,6 @@ impl ReleaseList {
     /// Retrieve a list of `Release`s.
     /// If specified, filter for those containing a specified `target`
     pub fn fetch(self) -> Result<Vec<Release>> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
             self.host,
@@ -170,10 +170,7 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(url)
             .headers(api_headers(&self.auth_token)?)
@@ -496,17 +493,13 @@ impl Update {
 
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
             self.host,
             urlencoding::encode(&self.repo_owner),
             self.repo_name
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
@@ -524,14 +517,14 @@ impl ReleaseUpdate for Update {
     }
 
     fn get_latest_releases(&self, current_version: &str) -> Result<Vec<Release>> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases",
             self.host,
             urlencoding::encode(&self.repo_owner),
             self.repo_name
         );
-        let resp = reqwest::blocking::Client::new()
+        let client = client()?;
+        let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)
             .send()?;
@@ -561,7 +554,6 @@ impl ReleaseUpdate for Update {
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        set_ssl_vars!();
         let api_url = format!(
             "{}/api/v4/projects/{}%2F{}/releases/{}",
             self.host,
@@ -569,10 +561,7 @@ impl ReleaseUpdate for Update {
             self.repo_name,
             ver
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client
             .get(&api_url)
             .headers(self.api_headers(&self.auth_token)?)

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -2,6 +2,7 @@
 Amazon S3 releases
 */
 use crate::{
+    client,
     errors::*,
     get_target,
     update::{Release, ReleaseAsset, ReleaseUpdate},
@@ -601,10 +602,7 @@ fn fetch_releases_from_s3(
 
     debug!("using api url: {:?}", api_url);
 
-    let client = reqwest::blocking::ClientBuilder::new()
-        .use_rustls_tls()
-        .http2_adaptive_window(true)
-        .build()?;
+    let client = client()?;
     let resp = client.get(&api_url).send()?;
     if !resp.status().is_success() {
         bail!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,20 @@ fn confirm(msg: &str) -> Result<()> {
     Ok(())
 }
 
+/// Build a blocking `reqwest` client.
+/// The Rustls TLS backend is used if and only if the `rustls` feature is enabled.
+fn client() -> Result<reqwest::blocking::Client> {
+    set_ssl_vars!();
+    #[cfg(not(feature = "rustls"))]
+    let client = reqwest::blocking::ClientBuilder::new();
+    #[cfg(feature = "rustls")]
+    let client = reqwest::blocking::ClientBuilder::new().use_rustls_tls();
+    client
+        .http2_adaptive_window(true)
+        .build()
+        .map_err(Into::into)
+}
+
 /// Status returned after updating
 ///
 /// Wrapped `String`s are version tags
@@ -689,11 +703,7 @@ impl Download {
             );
         }
 
-        set_ssl_vars!();
-        let client = reqwest::blocking::ClientBuilder::new()
-            .use_rustls_tls()
-            .http2_adaptive_window(true)
-            .build()?;
+        let client = client()?;
         let resp = client.get(&self.url).headers(headers).send()?;
         let size = resp
             .headers()


### PR DESCRIPTION
Currently, the rustls TLS backend from reqwest is always included and used even when the `rustls` feature is _not_ enabled, via the `use_rustls_tls` function call.

This is not only unexpected behaviour but also increases the size of application binaries since both the default (native_tls) and rustls backends are included.

When _only_ rustls is needed, use the `rustls` feature _and_ disable the default features.