### PR TITLE
fix: Handle paginated URLs and add HTTP timeouts

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -174,10 +174,13 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = http_client::get(
-            &format!("{url}?per_page=100"),
-            api_headers(&self.auth_token)?,
-        )?;
+        let request_url = if url.contains('?') {
+            // Pagination URL from Link header — already has query params
+            url.to_string()
+        } else {
+            format!("{url}?per_page=100")
+        };
+        let resp = http_client::get(&request_url, api_headers(&self.auth_token)?)?;
         if !resp.status().is_success() {
             bail!(
                 Error::Network,

--- a/src/http_client/reqwest.rs
+++ b/src/http_client/reqwest.rs
@@ -6,12 +6,18 @@ use super::{HeaderMap, HttpResponse};
 use crate::{Error, Result};
 
 pub fn get(url: &str, headers: HeaderMap) -> Result<impl HttpResponse> {
+    use std::time::Duration;
+
     let client_builder = reqwest::blocking::ClientBuilder::new();
 
     #[cfg(feature = "rustls")]
     let client_builder = client_builder.use_rustls_tls();
 
-    let client = client_builder.http2_adaptive_window(true).build()?;
+    let client = client_builder
+        .http2_adaptive_window(true)
+        .connect_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(300))
+        .build()?;
     let resp = client.get(url).headers(headers).send()?;
 
     if !resp.status().is_success() {


### PR DESCRIPTION
Release fetching now preserves pagination URLs that already contain query parameters (e.g. from Link headers) instead of unconditionally appending `?per_page=100`.  My project has more than 100 releases and this fixes it.

In addition, the reqwest HTTP client is configured with a 30s connect timeout and a 300s overall timeout (and imports Duration) to avoid long-hanging requests. These changes fix malformed pagination requests and make network calls more resilient.