### PR TITLE
fix: respect pagination URLs when fetching GitHub releases

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -174,10 +174,13 @@ impl ReleaseList {
     }
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
-        let resp = http_client::get(
-            &format!("{url}?per_page=100"),
-            api_headers(&self.auth_token)?,
-        )?;
+        let request_url = if url.contains('?') {
+            // Pagination URL from Link header — already has query params
+            url.to_string()
+        } else {
+            format!("{url}?per_page=100")
+        };
+        let resp = http_client::get(&request_url, api_headers(&self.auth_token)?)?;
         if !resp.status().is_success() {
             bail!(
                 Error::Network,

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -175,7 +175,7 @@ impl ReleaseList {
 
     fn fetch_releases(&self, url: &str) -> Result<Vec<Release>> {
         let request_url = if url.contains('?') {
-            // Pagination URL from Link header — already has query params
+            // Pagination URL from Link header - already has query params
             url.to_string()
         } else {
             format!("{url}?per_page=100")


### PR DESCRIPTION
Don't unconditionally append `?per_page=100` to the fetch URL. Pagination URLs from GitHub's Link header may already include query parameters; the code now checks for a '?' and uses the URL as-is if present, otherwise it appends `?per_page=100`. This prevents malformed requests and preserves pagination links.

see #178 