### PR TITLE
fix: show a short message when up to date

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -226,6 +226,7 @@ pub trait ReleaseUpdate {
                             );
                             release.clone()
                         } else {
+                            println(show_output, "up-to-date.");
                             return Ok(UpdateStatus::UpToDate);
                         }
                     }


### PR DESCRIPTION
Currently, it somewhats leaves things hanging if no new releases are available.

It outputs:

```
Checking target-arch... x86_64-unknown-linux-gnu
Checking current version... v1.4.2
Checking latest released version... %
```

The `%` is added by zsh and means that there is not even a `\n` added.

This patch changes it to:

```
Checking target-arch... x86_64-unknown-linux-gnu
Checking current version... v1.4.2
Checking latest released version... up-to-date.
```