### PR TITLE
release 1.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [unreleased]
 
+## [1.0.0-rc.3]
+Further 1.0 surface changes on top of rc.2: two API breaks (closing the async-blocking footgun and
+aligning the signature-key accessor name), plus correctness, security-hardening, and doc fixes. The
+breaks are folded into the [1.0 migration guide](docs/migrations/0.x-to-1.0-human.md).
+
+### Added
+- `is_update_available_async()` on every backend's async updater, the async sibling of
+  `is_update_available()`.
+- `max_download_size(bytes)` on `Download`: an optional cap that aborts a download whose body
+  exceeds it (default: no cap).
+- `Error::NoCurrentVersion`, returned by `Releases::is_update_available()` on a bare listing with no
+  current version (previously a misleading `MissingField { field: "current_version" }`).
+
+### Changed
+- `build_async()` returns a distinct `AsyncUpdate` wrapper per built-in backend
+  (`github::AsyncUpdate`, `gitlab::AsyncUpdate`, ...) instead of the same `Update` that `build()`
+  returns. The wrapper exposes only the async (`*_async`) verbs as inherent methods (no trait import
+  needed), so a blocking call such as `.update()` on an async-built updater is now a compile error
+  instead of silently blocking the executor. Migration: call the `*_async` verbs and drop any
+  `use self_update::AsyncReleaseUpdate`; if you named the return type, use the backend's `AsyncUpdate`.
+- Renamed the signature-key accessor `verify_keys()` -> `verifying_keys()`, matching the
+  `verifying_keys(...)` setter (`signatures` feature). Migration: rename accessor call sites; the
+  setter is unchanged.
+- `Releases::is_update_available()` on a bare listing now returns `Error::NoCurrentVersion` instead
+  of `Error::MissingField { field: "current_version" }`.
+- A user-supplied `Authorization` header (set via `request_header`) is now host-gated like the
+  derived auth token: it is not forwarded to a server-chosen next-page or download host unless that
+  host is authorized (`allow_auth_host` / a matching origin).
+- Zip extraction masks the setuid/setgid/sticky bits from archive entry modes (`mode & 0o777`), so
+  an archived `0o4755` entry no longer installs setuid.
+
+### Fixed
+- s3 `.release_tag("v1.2.3")` (v-prefixed) now matches; it previously always failed with
+  `NoReleaseFound` because stored s3 versions are bare semver.
+- The custom backend's `get_newer_releases()` now filters to strictly-newer releases, matching the
+  other backends and the trait contract (it previously returned the source's full list).
+- GCS bucket listings now paginate past the first page (the listing URL was missing `list-type=2`,
+  so continuation tokens were never emitted and later releases were dropped).
+- `version::bump_is_compatible` no longer reports a pre-release-to-older comparison (e.g.
+  `2.0.5-alpha.0` vs `2.0.3`) as compatible.
+- Presigned s3 URLs are redacted in the retry warn-logs (they were previously emitted with a live
+  `X-Amz-Signature`).
+- Listing response bodies are size-bounded before buffering, and `..` / path separators are
+  rejected in a templated `bin_path_in_archive` before extraction.
+
 ## [1.0.0-rc.2]
 Further breaking changes finalizing the 1.0 surface (still in release-candidate). They make the
 HTTP transport an injectable object-safe trait, restructure the error type, finalize the release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,44 @@
-### Contributing
+# Contributing
 
+## Verifying changes
 
-After making changes:
+Run the full CI pipeline locally before opening a PR:
 
-- Run tests: `cargo test`
-- Run example file as a simple integration test: `cargo run --example github`
-- Run cargo-fmt:
-    ```
-    # make sure rust-fmt is installed
-    rustup self update
-    rustup component add rustfmt-preview clippy
+```
+make ci
+```
 
-    # check
-    cargo fmt --all -- --check
-    cargo clippy --all-targets --all-features --examples --tests
-    # apply fixes
-    cargo fmt --all
-    ```
-- The project README.md is generated from the crate docs in `src/lib.rs` using `cargo-readme`
-    - All readme-content should be added/edited in the `src/lib` crate-level doc section,
-      and then the `readme.sh` script should be run to update the README.md.
-    ```
-    cargo install cargo-readme
-    ./readme.sh
-    ```
-- Update the CHANGELOG.md `unreleased` section with a summary of your changes
-- Open a PR to trigger CI builds for all platforms
+This runs `cargo fmt`, `cargo clippy`, and `cargo test` on both http clients (reqwest and
+ureq), checks the README is in sync, and builds every backend example. `make help` lists the
+individual targets.
 
+## README
 
-*Thank you!*
+`README.md` is generated from the crate docs in `src/lib.rs` using
+[cargo-readme](https://crates.io/crates/cargo-readme). Never edit it directly; edit the doc
+comment in `src/lib.rs` and regenerate:
+
+```
+cargo install cargo-readme
+./readme.sh          # regenerate README.md
+./readme.sh check    # verify it is in sync
+```
+
+## Changelog
+
+Add a summary of your change to the `[unreleased]` section of `CHANGELOG.md`.
+
+## Agent skills
+
+Agent-agnostic skills live in `.agents/skills/` (see [AGENTS.md](AGENTS.md) for the full
+list). In particular, the `pr-review` skill runs a read-only review of your branch or PR
+locally, so you can review your own changes before pushing.
+
+## Releases
+
+Publishing is done by the CI pipeline: every push to master runs the full check suite and then
+`cargo publish`, which only releases a new version when the version in `Cargo.toml` has been
+bumped. So if your change should go out immediately, use the `release` skill (or make the
+equivalent `CHANGELOG.md` updates) and bump the version in `Cargo.toml` as part of your PR.
+Otherwise the change sits in `[unreleased]` until a separate version-bump change triggers the
+next release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self_update"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 description = "Self updates for standalone executables"
 repository = "https://github.com/jaemk/self_update"
 keywords = ["update", "upgrade", "download", "release"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following are opt-in; activate the one(s) your release files need:
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;
 * `checksums`: verify a downloaded artifact against a known SHA-256/SHA-512 checksum (e.g. from a `SHA256SUMS` file) before installing it;
-* `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest handles async, ureq handles sync); see [Async](#async) below.
+* `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest serves the async path, and the sync API prefers reqwest when both are present); see [Async](#async) below.
 
 `github` is the only backend in the default feature set. The S3 backend requires the `s3` feature; `s3-auth` implies `s3`. `gitlab` and `gitea` each require their own feature.
 
@@ -316,18 +316,20 @@ fn update() -> Result<(), Box<dyn std::error::Error>> {
 ### Async
 
 With the `async` feature, every built-in backend's `Update` builder gains a `build_async()` that
-returns a concrete `Update` implementing the public sealed [`AsyncReleaseUpdate`] trait, with async
-(`*_async`) verbs — `update_async()`, `update_extended_async()`, `get_latest_release_async()`,
-`get_newer_releases_async()`, and `get_release_version_async()` — so a `tokio` application can
-update without wrapping the blocking calls in `spawn_blocking`. Bring [`AsyncReleaseUpdate`] into
-scope to call the verbs. The blocking API is unchanged; the async path is purely additive. It is
-**tokio-only and requires `reqwest`** -- ureq and reqwest can coexist (reqwest handles async, ureq
-handles sync); the only invalid configuration is `async` without `reqwest`.
-Network IO becomes async, and the extract/replace tail runs on `tokio::task::spawn_blocking` so it
-does not block the executor.
+returns a distinct `AsyncUpdate` wrapper (one per backend). Its async (`*_async`) verbs —
+`update_async()`, `update_extended_async()`, `get_latest_release_async()`,
+`get_newer_releases_async()`, `get_release_version_async()`, and `is_update_available_async()` — are
+**inherent methods** on that wrapper, so a `tokio` application can update without wrapping the
+blocking calls in `spawn_blocking` and without importing any trait. Crucially, the `AsyncUpdate`
+wrapper does **not** expose the blocking verbs: calling `.update()` on an async-built updater is a
+compile error, so the old footgun of accidentally running a blocking update from an async context
+is gone. The blocking API is unchanged; the async path is purely additive. It is **tokio-only and
+requires `reqwest`** -- ureq and reqwest can coexist (reqwest serves the async path, and the sync
+API prefers reqwest when both are present); the only invalid configuration is `async` without
+`reqwest`. Network IO becomes async, and the extract/replace tail runs on
+`tokio::task::spawn_blocking` so it does not block the executor.
 
 ```rust
-use self_update::AsyncReleaseUpdate;
 async fn update() -> Result<(), Box<dyn std::error::Error>> {
     let status = self_update::backends::github::Update::configure()
         .repo_owner("jaemk")
@@ -338,6 +340,27 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
         .update_async()
         .await?;
     println!("Update status: `{}`!", status.version());
+    Ok(())
+}
+```
+
+The `AsyncUpdate` wrapper exposes only the `*_async` verbs; the blocking `update()` is not a method
+on it, so accidentally calling it from async code does not compile. The following block is
+`compile_fail` for exactly that reason — `update` is not a method on the async wrapper (this block
+is intentionally not feature-gated: gating it behind `cfg(feature = "async")` would make it an empty,
+successfully-compiling doctest in the crate's no-`async` test lanes, which a `compile_fail` block
+must never do):
+
+```rust,compile_fail
+fn wont_compile() -> Result<(), Box<dyn std::error::Error>> {
+    let updater = self_update::backends::github::Update::configure()
+        .repo_owner("jaemk")
+        .repo_name("self_update")
+        .bin_name("github")
+        .current_version(self_update::cargo_crate_version!())
+        .build_async()?;
+    // `update()` is the BLOCKING verb; it is not exposed on the async `AsyncUpdate` wrapper.
+    updater.update()?;
     Ok(())
 }
 ```
@@ -356,8 +379,8 @@ need a separate dependency to name the type. (Since the transport is a runtime t
 and `ureq` are no longer mutually exclusive — both can be enabled, and the sync API prefers reqwest
 when both are present.) For test doubles or fully custom transport, inject any type that implements
 the object-safe trait directly via `.http_client(Arc<dyn HttpClient>)` (sync) or
-`.http_client_async(Arc<dyn AsyncHttpClient>)` (async); see the [`self_update::http_client`] module
-for the trait definitions.
+`.http_client_async(Arc<dyn AsyncHttpClient>)` (async); see the [`http_client`](crate::http_client)
+module for the trait definitions.
 
 When you inject a client, `.request_header()` still applies, and `.retries()` still applies to the
 release-listing requests and to the download's request-establishment phase (a mid-stream failure

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # self_update
 
 
-[![Build status](https://ci.appveyor.com/api/projects/status/xlkq8rd73cla4ixw/branch/master?svg=true)](https://ci.appveyor.com/project/jaemk/self-update/branch/master)
 [![crates.io:clin](https://img.shields.io/crates/v/self_update.svg?label=self_update)](https://crates.io/crates/self_update)
 [![docs](https://docs.rs/self_update/badge.svg)](https://docs.rs/self_update)
 

--- a/docs/migrations/0.x-to-1.0-human.md
+++ b/docs/migrations/0.x-to-1.0-human.md
@@ -32,8 +32,8 @@ longer have to remember which backend calls a thing what.
 | `.set_headers(map)` | `.replace_headers(map)` | `Download` |
 | `.verify_with(\|p\| -> bool)` | `.verify_binary(\|p\| -> Result<()>)` | every `Update` builder (see section 7) |
 
-The signature-key setter `verifying_keys(..)` (`signatures` feature) keeps its 0.x name; only
-its read accessor is `verify_keys()` (see section 3).
+The signature-key setter `verifying_keys(..)` (`signatures` feature) keeps its 0.x name; its
+read accessor is now also `verifying_keys()` (renamed from `verify_keys()`, see section 3).
 
 **Why:** the names were tidied so that setters and accessors match (e.g. the `release_tag` /
 `asset_identifier` setter now reads back under the same name), so the standalone `Download`
@@ -204,7 +204,9 @@ if let Error::Transport(e) = &err {
 > will flag any exhaustive match that no longer covers all variants. The `Download`, `Extract`,
 > `Move`, and `MoveAll` utility structs are also `#[non_exhaustive]` now (their fields were already
 > private, so this only blocks a future struct-literal construction), as are each backend's
-> concrete `Update` struct and `custom::AsyncUpdate` (the values `build_async()` returns).
+> concrete `Update` struct (returned by `build()`), each backend's `AsyncUpdate` wrapper
+> (e.g. `github::AsyncUpdate`, returned by `build_async()`), and `custom::AsyncUpdate`
+> (returned by `custom::build_async()`).
 
 > **Note:** the two update-result enums were renamed. `Status` (the result of `update()`, carrying
 > a version string) is now `VersionStatus`, and `UpdateStatus` (the result of `update_extended()`,
@@ -219,9 +221,9 @@ if let Error::Transport(e) = &err {
 The accessor methods on the `ReleaseUpdate` trait now return `&str` / `Option<&str>` instead of
 owned `String` / `Option<String>` (`current_version`, `target`, `bin_name`,
 `bin_path_in_archive`, `progress_template`, `progress_chars`, `release_tag`, `asset_identifier`,
-`auth_token`). `bin_install_path` returns `&Path` instead of an owned `PathBuf`. The `verify_keys`
-accessor (`signatures` feature) similarly returns `&[VerifyingKey]` instead of
-`Vec<VerifyingKey>`; its setter keeps the 0.x name `verifying_keys(...)`.
+`auth_token`). `bin_install_path` returns `&Path` instead of an owned `PathBuf`. The `verifying_keys`
+accessor (`signatures` feature, renamed from `verify_keys`) similarly returns `&[VerifyingKey]`
+instead of `Vec<VerifyingKey>`; setter and accessor now share the name `verifying_keys`.
 
 **Why:** these are simple field reads; returning owned `String`s forced an allocation on every
 call for no reason. This is the kind of signature that can't be fixed after 1.0, so it had to
@@ -492,7 +494,10 @@ only use the built-in github/gitlab/gitea/s3 backends can skip this section.
 
 **`ReleaseSource` is sync.** It is three plain sync fetch methods (and no `Clone` requirement), with
 no defaulted `*_async` helpers. The sync and async worlds are mirror images of each other, just like
-the built-in backends' `build()` vs `build_async()`:
+the built-in backends' `build()` vs `build_async()`: `build()` returns the concrete blocking
+`Update`; `build_async()` returns a per-backend `AsyncUpdate` wrapper (e.g. `github::AsyncUpdate`)
+that exposes only the `*_async` verbs as inherent methods (no `use self_update::AsyncReleaseUpdate`
+import needed), so calling a blocking `.update()` on it is a compile error.
 
 - **Native async source:** implement the `AsyncReleaseSource` trait, the same three fetches, with
   clean names (`get_latest_release`, `get_latest_releases`, `get_release_version`, **no** `_async`
@@ -552,8 +557,10 @@ constructors instead: `Error::no_release_found(target)`, `Error::missing_asset_f
 (`bin_name`, `current_version`, `target`, ...) now live on a new supertrait
 `self_update::UpdateConfig` (and `ReleaseUpdate: UpdateConfig`). The update verbs are inherent on
 the concrete `Update` (section 4), so a plain `.build()?.update()?` chain needs no import; calling
-an accessor needs `use self_update::UpdateConfig;` in scope, as does a generic helper written
-`fn f<R: ReleaseUpdate>(u: &R)` that calls one.
+an accessor on a concrete `Update` value needs `use self_update::UpdateConfig;` in scope. A generic
+helper written `fn f<R: ReleaseUpdate>(u: &R)` that calls one needs no import: the `R: ReleaseUpdate`
+bound already brings the supertrait accessors into scope. Likewise a call through a
+`dyn ReleaseUpdate` needs no import.
 
 ## 11. Behavior changes (no code edit needed)
 
@@ -611,7 +618,7 @@ These aren't required, but 1.0 makes a few things pleasanter:
 - **Verifying keys are easier:** use the `self_update::VerifyingKey` alias instead of
   `[u8; zipsign_api::PUBLIC_KEY_LENGTH]`, and the `zipsign_api` crate is re-exported as
   `self_update::zipsign_api` (both under the `signatures` feature). The `verifying_keys(...)`
-  setter and the `verify_keys()` accessor now speak this alias directly.
+  setter and the `verifying_keys()` accessor now speak this alias directly.
 - **The S3 credential type is nameable:** `self_update::backends::s3::AccessKey` (under `s3-auth`)
   is now public. You normally just pass an `(id, secret)` tuple to `.access_key(...)`; the type
   is `#[non_exhaustive]` so a future field (e.g. an STS session token) can be added without a

--- a/docs/migrations/0.x-to-1.0.md
+++ b/docs/migrations/0.x-to-1.0.md
@@ -42,7 +42,7 @@ builder or `Download`, scope the replacement to the `self_update` call sites nam
 | 1.11 | `.set_timeout(` | `.timeout(` | `Download`, matches the `Update`/`ReleaseList` builders' `.timeout(`. |
 | 1.12 | `.set_header(` | `.request_header(` | `Download` additive single-header setter. Distinct from `replace_headers` (1.5), and named to match the `Update`/`ReleaseList` builders' `request_header`. Now takes `TryInto<HeaderName>`/`TryInto<HeaderValue>` and returns `&mut Self`, so string literals work, e.g. `.request_header("Accept", "application/octet-stream")`; an invalid header surfaces from `download_to` as `Error::InvalidHeader` (see 1a). |
 | 1.13 | `.verifying_checksum(` / `.checksum(` | `.verify_checksum(` | every `Update` builder (`checksums` feature); matches the `verify_checksum()` accessor (set/get align). `.checksum(` covers an earlier 1.0 pre-release. |
-| 1.14 | `.verify_keys(` | `.verifying_keys(` | every `Update` builder (`signatures` feature). The 0.x setter name `verifying_keys` is unchanged in 1.0; only rewrite a `.verify_keys(` setter call from an earlier 1.0 pre-release. The read accessor is `verify_keys()` (do not rewrite accessor call sites). |
+| 1.14 | `.verify_keys(` | `.verifying_keys(` | every `Update` builder (`signatures` feature). The 0.x setter name `verifying_keys` is unchanged in 1.0; a 0.x user who only set keys needs no change. Rewrite any `.verify_keys(` call (whether a setter call from an earlier 1.0 pre-release or a READ-accessor call from 0.x or an earlier pre-release) to `verifying_keys`. Both setter and accessor are `verifying_keys` in 1.0. |
 
 These renames are unambiguous: the old names no longer exist in 1.0, so any remaining
 occurrence is a real call site to convert. The old names are not kept as `#[doc(alias)]`s (the
@@ -233,8 +233,9 @@ programmatic decisions, do not parse the Display output.
 them, especially `VersionStatus` (returned by every `update()` call), must gain a `_ =>` arm. The
 compiler will flag any non-exhaustive pattern. The `Download`, `Extract`, `Move`, and `MoveAll`
 utility structs are also `#[non_exhaustive]` (their fields are already private, so this only blocks
-a future struct-literal construction), as are each backend's concrete `Update` struct and
-`custom::AsyncUpdate` (the return types of `build_async()`).
+a future struct-literal construction), as are each backend's concrete `Update` struct (returned by `build()`), each backend's
+`AsyncUpdate` wrapper (e.g. `github::AsyncUpdate`, returned by `build_async()`), and
+`custom::AsyncUpdate` (returned by `custom::build_async()`).
 
 ## 2a. Status enum renames + predicate renames (mechanical)
 
@@ -266,8 +267,7 @@ The `ReleaseUpdate` trait accessors now return borrows:
   return `Option<&str>` (were `Option<String>`).
 - `bin_install_path` returns `&std::path::Path` (was an owned `PathBuf`). Only relevant if you
   named the return type; append `.to_path_buf()` where you need ownership.
-- `verify_keys` (`signatures` feature) returns `&[VerifyingKey]` (was `Vec<VerifyingKey>`). The
-  accessor keeps this name; the setter stays `verifying_keys` (see §1.14).
+- `verifying_keys` (`signatures` feature) returns `&[VerifyingKey]` (was `Vec<VerifyingKey>` under the old `verify_keys` accessor name). The accessor was renamed from `verify_keys` to `verifying_keys`; both setter and accessor now share the name `verifying_keys` (see §1.14).
 
 Fix sites where ownership is required: append `.to_string()` / `.map(str::to_owned)`.
 - `let v: String = updater.current_version();` -> `let v: String = updater.current_version().to_string();`
@@ -636,12 +636,12 @@ construction fails downstream).
 `bin_install_path`, `bin_path_in_archive`, the progress/transport/verify getters, `api_headers`,
 ...) now live on a new sealed supertrait `self_update::UpdateConfig`, and `ReleaseUpdate: UpdateConfig`
 keeps only the fetches plus `update`/`update_extended`. The update verbs are inherent on the
-concrete `Update` that `build()` returns (§3a), so plain update chains need no import; a call site
-that reads an accessor needs `use self_update::UpdateConfig;` in scope, as does a generic helper
-bounded `R: ReleaseUpdate` that calls one (or bound `R: ReleaseUpdate + UpdateConfig`, which is
-implied but makes the methods visible). Error:
-`no method named `bin_name`/`current_version`/... found for type parameter` (or for the concrete
-`Update` when the trait is not in scope).
+concrete `Update` that `build()` returns (§3a), so plain update chains need no import. Reading an
+accessor on a concrete `Update` value needs `use self_update::UpdateConfig;` in scope. A generic
+helper bounded `R: ReleaseUpdate`, or a call through a `dyn ReleaseUpdate`, needs no import: the
+`R: ReleaseUpdate` bound (and the trait object's own trait) already brings the supertrait accessors
+into scope. Error: `no method named `bin_name`/`current_version`/... found` for the concrete
+`Update` value when the trait is not in scope.
 
 ---
 
@@ -671,7 +671,7 @@ A successful build with no `self_update`-related errors means the migration is c
 | `no method named `set_progress_callback`` / `set_progress_style`` | §1.9 / §1.10 |
 | `no method named `set_timeout`` / `set_header`` (`Download`) | §1.11 / §1.12 |
 | `no method named `verifying_checksum`` / `checksum`` (an `Update` builder) | §1.13 (now `verify_checksum`) |
-| `no method named `verify_keys`` (an `Update` builder) | §1.14 (the setter is `verifying_keys`; unchanged from 0.x) |
+| `no method named `verify_keys`` | §1.14 (both setter and accessor are `verifying_keys` in 1.0; rewrite any `verify_keys` call, setter or accessor, to `verifying_keys`) |
 | `cannot infer type` at a `.parse()` inside `request_header(` | §1a (pass the `&str` directly, drop `.parse().unwrap()`) |
 | `no method named `header` ... `Download`` | §1.12 / §1a (now `request_header`) |
 | `the `?` operator cannot be applied to ... &mut Download` at `request_header(` | §1a (setter is infallible; drop the `?`, the error surfaces from `download_to`) |
@@ -714,4 +714,4 @@ A successful build with no `self_update`-related errors means the migration is c
 | `cannot find type `GetArchiveReaderResult`` | §6 |
 | `cannot find function `should_update`` | §6 |
 | `no method named `get_latest_release_async`/`get_latest_releases_async`/`get_release_version_async`` on a `ReleaseSource` | §9a (methods removed; implement `AsyncReleaseSource` or wrap a sync source in `Blocking`) |
-| `no method named `bin_name`/`current_version`/`target`/... found for type parameter` (generic `R: ReleaseUpdate`) | §9c (add `use self_update::UpdateConfig;`) |
+| `no method named `bin_name`/`current_version`/`target`/... found` for a concrete `Update` value | §9c (add `use self_update::UpdateConfig;`; not needed for a generic `R: ReleaseUpdate` bound or a `dyn ReleaseUpdate`) |

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -257,7 +257,7 @@ impl RequestConfig {
     /// [`auth_hosts`](Self::auth_hosts) entry, and the scheme must be `https` -- except for loopback
     /// hosts (`localhost`, `127.0.0.1`, `::1`), which are allowed over plain http so a local mirror
     /// and the loopback test stubs keep working.
-    fn auth_allowed_for(&self, url: &str) -> bool {
+    pub(crate) fn auth_allowed_for(&self, url: &str) -> bool {
         let uri = match url.parse::<http::Uri>() {
             Ok(u) => u,
             Err(_) => return false,

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -2,7 +2,7 @@
 Updates from a user-defined release source.
 
 Use this backend to update from a host the built-in backends (`github`, `gitlab`, `gitea`, `s3`)
-don't cover. Implement [`ReleaseSource`](crate::ReleaseSource) for your host — the three methods
+don't cover. Implement [`ReleaseSource`] for your host — the three methods
 that say *where releases come from* — then configure a [`custom::Update`](Update) with the same
 shared options as any other backend (target, bin name, version, progress, transport, checksum,
 verify hook, asset matcher, …) and call `update()`. The crate runs its usual compare →
@@ -224,7 +224,14 @@ impl ReleaseUpdate for Update {
 
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = self.source.get_latest_releases()?;
+        let releases = self
+            .source
+            .get_latest_releases()?
+            .into_iter()
+            .filter(|r| {
+                crate::version::bump_is_greater(&current_version, r.version()).unwrap_or(false)
+            })
+            .collect();
         Ok(Releases::new(releases, current_version))
     }
 
@@ -327,6 +334,22 @@ impl<S: crate::update::AsyncReleaseSource> AsyncUpdate<S> {
     pub fn configure() -> AsyncUpdateBuilder<S> {
         AsyncUpdateBuilder::new()
     }
+
+    /// Whether a release newer than the current version is available, returning it if so.
+    ///
+    /// Async sibling of the sync `is_update_available`, and a convenience over
+    /// [`get_newer_releases_async`](crate::AsyncReleaseUpdate::get_newer_releases_async): returns the
+    /// newest strictly-newer [`Release`], or `None` when already up to date. The strictly-newer
+    /// filter lives in `get_newer_releases_async`; this method simply returns the first result.
+    pub async fn is_update_available_async(&self) -> Result<Option<Release>> {
+        Ok(
+            crate::update::AsyncReleaseUpdate::get_newer_releases_async(self)
+                .await?
+                .into_vec()
+                .into_iter()
+                .next(),
+        )
+    }
 }
 
 #[cfg(feature = "async")]
@@ -344,7 +367,15 @@ impl<S: crate::update::AsyncReleaseSource> crate::update::AsyncReleaseUpdate for
     }
     async fn get_newer_releases_async(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = self.source.get_latest_releases().await?;
+        let releases = self
+            .source
+            .get_latest_releases()
+            .await?
+            .into_iter()
+            .filter(|r| {
+                crate::version::bump_is_greater(&current_version, r.version()).unwrap_or(false)
+            })
+            .collect();
         Ok(Releases::new(releases, current_version))
     }
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
@@ -550,6 +581,73 @@ mod tests {
                 .is_update_available()
                 .unwrap(),
             "latest (2.0.0) is not newer than current (2.0.0) => no update"
+        );
+    }
+
+    // C2: get_newer_releases must filter to strictly-newer releases only.
+    //
+    // A source that returns a mix of older-than-current, equal-to-current, and newer-than-current
+    // releases. The fixed `get_newer_releases` must exclude the first two groups; the bug (returning
+    // the unfiltered list verbatim) would cause these tests to fail.
+    struct MultiVersionSource;
+
+    impl ReleaseSource for MultiVersionSource {
+        fn get_latest_release(&self) -> crate::errors::Result<Release> {
+            Release::builder().version("3.0.0").build()
+        }
+        fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+            Ok(vec![
+                Release::builder().version("3.0.0").build()?,
+                Release::builder().version("2.0.0").build()?,
+                Release::builder().version("1.5.0").build()?,
+                // equal to current (1.0.0) -- must be excluded
+                Release::builder().version("1.0.0").build()?,
+                // older than current -- must be excluded
+                Release::builder().version("0.9.0").build()?,
+            ])
+        }
+        fn get_release_version(&self, ver: &str) -> crate::errors::Result<Release> {
+            Release::builder().version(ver).build()
+        }
+    }
+
+    #[test]
+    fn get_newer_releases_excludes_equal_and_older_releases() {
+        // C2 (sync): the returned Releases must contain only releases strictly newer than the
+        // configured current version. The old code returned the source's list verbatim (5 items);
+        // the fix must drop the equal (1.0.0) and older (0.9.0) entries, leaving 3.
+        let upd = Update::configure()
+            .source(MultiVersionSource)
+            .bin_name("app")
+            .target("x86_64-unknown-linux-gnu")
+            .current_version("1.0.0")
+            .build()
+            .unwrap();
+        let rels = upd.get_newer_releases().unwrap();
+        let versions: Vec<&str> = rels.all().iter().map(|r| r.version()).collect();
+        assert_eq!(
+            versions,
+            vec!["3.0.0", "2.0.0", "1.5.0"],
+            "get_newer_releases must exclude equal-to-current (1.0.0) and older (0.9.0)"
+        );
+    }
+
+    #[test]
+    fn get_newer_releases_returns_empty_when_all_releases_are_current_or_older() {
+        // C2 (sync): when every release the source returns is the current version or older, the
+        // filtered result must be an empty list (not the full unfiltered list).
+        let upd = Update::configure()
+            .source(MultiVersionSource)
+            .bin_name("app")
+            .target("x86_64-unknown-linux-gnu")
+            .current_version("3.0.0")
+            .build()
+            .unwrap();
+        let rels = upd.get_newer_releases().unwrap();
+        assert!(
+            rels.all().is_empty(),
+            "get_newer_releases must return an empty list when nothing is strictly newer; got {:?}",
+            rels.all().iter().map(|r| r.version()).collect::<Vec<_>>()
         );
     }
 
@@ -1226,6 +1324,107 @@ mod tests {
                     .is_update_available()
                     .unwrap(),
                 "2.0.0 not newer than 2.0.0 => no update"
+            );
+        }
+
+        #[tokio::test]
+        async fn is_update_available_async_verb_returns_newest_newer_or_none() {
+            // Exercises the inherent `AsyncUpdate::is_update_available_async` convenience directly:
+            // it must return the newest strictly-newer release, or `None` when already current.
+            let mk = |cur: &str| {
+                AsyncUpdate::configure()
+                    .source(NativeAsyncSource {
+                        latest_calls: Arc::new(AtomicUsize::new(0)),
+                        releases_calls: Arc::new(AtomicUsize::new(0)),
+                        version_calls: Arc::new(AtomicUsize::new(0)),
+                    })
+                    .bin_name("app")
+                    .target("x86_64-unknown-linux-gnu")
+                    .current_version(cur)
+                    .build_async()
+                    .unwrap()
+            };
+            let newer = mk("1.0.0").is_update_available_async().await.unwrap();
+            assert_eq!(
+                newer.map(|r| r.version().to_string()),
+                Some("2.0.0".to_string()),
+                "from 1.0.0 the 2.0.0 release is available"
+            );
+            assert!(
+                mk("2.0.0")
+                    .is_update_available_async()
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "from 2.0.0 nothing newer => None"
+            );
+        }
+
+        // C2 (async): get_newer_releases_async must filter to strictly-newer releases only.
+
+        struct MultiVersionAsyncSource;
+
+        impl AsyncReleaseSource for MultiVersionAsyncSource {
+            async fn get_latest_release(&self) -> crate::errors::Result<Release> {
+                Release::builder().version("3.0.0").build()
+            }
+            async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                Ok(vec![
+                    Release::builder().version("3.0.0").build()?,
+                    Release::builder().version("2.0.0").build()?,
+                    Release::builder().version("1.5.0").build()?,
+                    // equal to current -- must be excluded
+                    Release::builder().version("1.0.0").build()?,
+                    // older than current -- must be excluded
+                    Release::builder().version("0.9.0").build()?,
+                ])
+            }
+            async fn get_release_version(&self, ver: &str) -> crate::errors::Result<Release> {
+                Release::builder().version(ver).build()
+            }
+        }
+
+        #[tokio::test]
+        async fn get_newer_releases_async_excludes_equal_and_older_releases() {
+            // C2 (async): the returned Releases must contain only releases strictly newer than the
+            // configured current version. The old code returned the source's list verbatim (5
+            // items); the fix must drop equal (1.0.0) and older (0.9.0), leaving 3.
+            let upd = AsyncUpdate::configure()
+                .source(MultiVersionAsyncSource)
+                .bin_name("app")
+                .target("x86_64-unknown-linux-gnu")
+                .current_version("1.0.0")
+                .build_async()
+                .unwrap();
+            let rels = AsyncReleaseUpdate::get_newer_releases_async(&upd)
+                .await
+                .unwrap();
+            let versions: Vec<&str> = rels.all().iter().map(|r| r.version()).collect();
+            assert_eq!(
+                versions,
+                vec!["3.0.0", "2.0.0", "1.5.0"],
+                "get_newer_releases_async must exclude equal-to-current (1.0.0) and older (0.9.0)"
+            );
+        }
+
+        #[tokio::test]
+        async fn get_newer_releases_async_returns_empty_when_all_current_or_older() {
+            // C2 (async): when every release the source returns is the current version or older,
+            // the filtered result must be an empty list.
+            let upd = AsyncUpdate::configure()
+                .source(MultiVersionAsyncSource)
+                .bin_name("app")
+                .target("x86_64-unknown-linux-gnu")
+                .current_version("3.0.0")
+                .build_async()
+                .unwrap();
+            let rels = AsyncReleaseUpdate::get_newer_releases_async(&upd)
+                .await
+                .unwrap();
+            assert!(
+                rels.all().is_empty(),
+                "get_newer_releases_async must return empty when nothing is strictly newer; got {:?}",
+                rels.all().iter().map(|r| r.version()).collect::<Vec<_>>()
             );
         }
 

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -91,6 +91,11 @@ impl ReleaseListBuilder {
     ///
     /// Pass the instance host only (scheme + host, no trailing slash); the crate appends the
     /// `/api/v1/...` path itself. Do not include `/api/v1`.
+    ///
+    /// Note: this setter differs from `github`'s `api_base_url` (which takes the full API base
+    /// URL including any path prefix, e.g. `https://api.github.com`) and from `s3`'s `endpoint`
+    /// (which selects the S3 service type and endpoint). Each backend's custom-URL setter has a
+    /// different shape matching its API's structure.
     pub fn host(&mut self, url: impl Into<String>) -> &mut Self {
         self.host = Some(url.into());
         self
@@ -205,7 +210,9 @@ impl ReleaseList {
     pub fn fetch(&self) -> Result<Releases> {
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
-            self.host, self.repo_owner, self.repo_name
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         );
 
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
@@ -225,7 +232,9 @@ impl ReleaseList {
     pub async fn fetch_async(&self) -> Result<Releases> {
         let api_url = format!(
             "{}/api/v1/repos/{}/{}/releases",
-            self.host, self.repo_owner, self.repo_name
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         );
 
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
@@ -269,6 +278,11 @@ impl UpdateBuilder {
     ///
     /// Pass the instance host only (scheme + host, no trailing slash); the crate appends the
     /// `/api/v1/...` path itself. Do not include `/api/v1`.
+    ///
+    /// Note: this setter differs from `github`'s `api_base_url` (which takes the full API base
+    /// URL including any path prefix, e.g. `https://api.github.com`) and from `s3`'s `endpoint`
+    /// (which selects the S3 service type and endpoint). Each backend's custom-URL setter has a
+    /// different shape matching its API's structure.
     pub fn host(&mut self, url: impl Into<String>) -> &mut Self {
         self.host = Some(url.into());
         self
@@ -327,13 +341,14 @@ impl UpdateBuilder {
         self.build_update()
     }
 
-    /// Confirm config and create a ready-to-use `Update` for the async API (`update_async`).
+    /// Confirm config and create a ready-to-use [`AsyncUpdate`] for the async API (`update_async`).
     ///
-    /// Unlike [`build`](Self::build) this returns the concrete `Update` (not a
-    /// `Box<dyn ReleaseUpdate>`) so the inherent `*_async` methods are reachable.
+    /// Unlike [`build`](Self::build) this returns the distinct [`AsyncUpdate`] newtype, which exposes
+    /// only the inherent `*_async` verbs, so a stray blocking `.update()` on an async-built updater
+    /// is a compile error rather than a silent block of the executor.
     #[cfg(feature = "async")]
-    pub fn build_async(&self) -> Result<Update> {
-        self.build_update()
+    pub fn build_async(&self) -> Result<AsyncUpdate> {
+        Ok(AsyncUpdate(self.build_update()?))
     }
 }
 
@@ -356,7 +371,9 @@ impl Update {
     fn releases_url(&self) -> String {
         format!(
             "{}/api/v1/repos/{}/{}/releases",
-            self.host, self.repo_owner, self.repo_name
+            self.host,
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         )
     }
 }
@@ -400,6 +417,19 @@ impl ReleaseUpdate for Update {
 }
 
 impl_sync_update_verbs!(Update);
+
+/// Async-only updater returned by [`UpdateBuilder::build_async`].
+///
+/// A newtype over the blocking [`Update`] that exposes **only** the inherent `*_async` verbs. Using
+/// it (instead of returning `Update` from `build_async`) makes a blocking call on an async-built
+/// updater — e.g. `build_async()?.update()` — a compile error, so the async executor cannot be
+/// silently blocked.
+#[cfg(feature = "async")]
+#[derive(Debug)]
+pub struct AsyncUpdate(Update);
+
+#[cfg(feature = "async")]
+impl_async_update_verbs!(AsyncUpdate);
 
 impl_update_config_accessors!(Update, {
     fn api_headers(&self, _auth_token: Option<&str>) -> Result<header::HeaderMap> {
@@ -454,9 +484,15 @@ fn release_array_page(
                 }
                 items.push(release);
             }
-            let next = next_link(resp_headers).map(|next_url| {
-                release_array_page(next_url, api_headers().unwrap_or_default(), stop_at.clone())
-            });
+            let next = next_link(resp_headers)
+                .map(|next_url| -> Result<PageRequest<Release>> {
+                    Ok(release_array_page(
+                        next_url,
+                        api_headers()?,
+                        stop_at.clone(),
+                    ))
+                })
+                .transpose()?;
             Ok(Page {
                 items,
                 next,
@@ -556,9 +592,6 @@ mod tests {
     use super::Update;
     use crate::update::UpdateConfig;
 
-    #[cfg(feature = "async")]
-    use crate::update::AsyncReleaseUpdate;
-
     /// Async test wrapper over `releases_plan` + the async driver (unfiltered, all pages).
     #[cfg(feature = "async")]
     async fn fetch_all_releases_async(
@@ -643,7 +676,7 @@ mod tests {
     }
 
     #[cfg(feature = "async")]
-    fn gitea_update(base: &str, current_version: &str) -> Update {
+    fn gitea_update(base: &str, current_version: &str) -> super::AsyncUpdate {
         Update::configure()
             .host(base)
             .repo_owner("o")
@@ -1004,7 +1037,7 @@ mod tests {
 
     // --- the listing `Releases` from `ReleaseList::fetch` carries NO current
     // version, so `current_version()` is `None` and `is_update_available()` errors with EXACTLY
-    // `MissingField { field: "current_version" }`. `into_vec()` recovers the release vec.
+    // `NoCurrentVersion`. `into_vec()` recovers the release vec.
     #[test]
     fn release_list_fetch_returns_listing_releases_without_current_version() {
         let base = stub(|_| {
@@ -1030,11 +1063,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on a listing must error with MissingField, got {:?}",
+            "is_update_available() on a listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let versions: Vec<String> = releases
@@ -1050,7 +1081,7 @@ mod tests {
     }
 
     // --- async sibling of `release_list_fetch_returns_listing_releases_without_current_version`:
-    // `ReleaseList::fetch_async` yields the same bare listing (no current version, MissingField
+    // `ReleaseList::fetch_async` yields the same bare listing (no current version, NoCurrentVersion
     // from `is_update_available()`, `into_vec()` recovers the releases).
     #[cfg(feature = "async")]
     #[tokio::test]
@@ -1079,11 +1110,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on a listing must error with MissingField, got {:?}",
+            "is_update_available() on a listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let versions: Vec<String> = releases
@@ -1337,6 +1366,61 @@ mod tests {
         assert_eq!(
             upd.releases_url(),
             "https://gitea.example.com/api/v1/repos/owner/repo/releases"
+        );
+    }
+
+    // --- I3: releases_url percent-encodes owner and name ------------------------------------
+    //
+    // `repo_owner` / `repo_name` containing URL-special characters (e.g. a space) must be
+    // percent-encoded in the releases URL, matching gitlab's behavior. A space becomes %20;
+    // plain alphanumeric names are unaffected.
+
+    #[test]
+    fn releases_url_encodes_owner_and_name() {
+        // A space in repo_owner and repo_name must be encoded as %20 in the URL.
+        // Without the fix the raw space appears in the path and breaks HTTP requests.
+        let upd = Update::configure()
+            .host("https://gitea.example.com")
+            .repo_owner("my owner")
+            .repo_name("my repo")
+            .bin_name("app")
+            .current_version("0.1.0")
+            .build_update()
+            .unwrap();
+        assert_eq!(
+            upd.releases_url(),
+            "https://gitea.example.com/api/v1/repos/my%20owner/my%20repo/releases",
+            "repo_owner and repo_name must be percent-encoded in the releases URL"
+        );
+    }
+
+    #[test]
+    fn release_list_fetch_encodes_owner_and_name_in_request_path() {
+        // `ReleaseList::fetch` must also percent-encode owner/name in the actual HTTP request.
+        // Captures the raw request line and asserts the encoded form appears in the path.
+        let (base, captured) = stub_capturing(|_| {
+            vec![Resp {
+                status: "200 OK",
+                link: None,
+                body: releases_json(&["v1.0.0"]),
+            }]
+        });
+        super::ReleaseList::configure()
+            .host(&base)
+            .repo_owner("my owner")
+            .repo_name("my repo")
+            .build()
+            .unwrap()
+            .fetch()
+            .unwrap();
+        let reqs = captured.lock().unwrap();
+        assert_eq!(reqs.len(), 1, "exactly one request must be made");
+        let request_line = reqs[0].lines().next().unwrap_or("");
+        assert!(
+            request_line.contains("/api/v1/repos/my%20owner/my%20repo/releases"),
+            "owner and name must be percent-encoded in the ReleaseList::fetch request path; \
+             got request line: {}",
+            request_line
         );
     }
 

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -104,6 +104,12 @@ impl ReleaseListBuilder {
     /// Set the optional github url, e.g. for a github enterprise installation.
     /// The url should provide the path to your API endpoint and end without a trailing slash,
     /// for example `https://api.github.com` or `https://github.mycorp.com/api/v3`
+    ///
+    /// **Semantic note:** this setter takes the full API base URL (ending at the version prefix,
+    /// e.g. `.../api/v3`). The gitea and gitlab backends instead accept an instance host and
+    /// append the API path internally; the s3 backend uses an `endpoint` setter. The difference
+    /// is intentional: GitHub enterprise instances expose configurable API prefixes, whereas the
+    /// other backends have fixed API paths relative to their host.
     pub fn api_base_url(&mut self, url: impl Into<String>) -> &mut Self {
         self.custom_url = Some(url.into());
         self
@@ -321,13 +327,14 @@ impl UpdateBuilder {
         self.build_update()
     }
 
-    /// Confirm config and create a ready-to-use `Update` for the async API (`update_async`).
+    /// Confirm config and create a ready-to-use [`AsyncUpdate`] for the async API (`update_async`).
     ///
-    /// Unlike [`build`](Self::build) this returns the concrete `Update` (not a
-    /// `Box<dyn ReleaseUpdate>`) so the inherent `*_async` methods are reachable.
+    /// Unlike [`build`](Self::build) this returns the distinct [`AsyncUpdate`] newtype, which exposes
+    /// only the inherent `*_async` verbs, so a stray blocking `.update()` on an async-built updater
+    /// is a compile error rather than a silent block of the executor.
     #[cfg(feature = "async")]
-    pub fn build_async(&self) -> Result<Update> {
-        self.build_update()
+    pub fn build_async(&self) -> Result<AsyncUpdate> {
+        Ok(AsyncUpdate(self.build_update()?))
     }
 }
 
@@ -431,9 +438,22 @@ impl ReleaseUpdate for Update {
 
 impl_sync_update_verbs!(Update);
 
+/// Async-only updater returned by [`UpdateBuilder::build_async`].
+///
+/// A newtype over the blocking [`Update`] that exposes **only** the inherent `*_async` verbs. Using
+/// it (instead of returning `Update` from `build_async`) makes a blocking call on an async-built
+/// updater — e.g. `build_async()?.update()` — a compile error, so the async executor cannot be
+/// silently blocked.
+#[cfg(feature = "async")]
+#[derive(Debug)]
+pub struct AsyncUpdate(Update);
+
+#[cfg(feature = "async")]
+impl_async_update_verbs!(AsyncUpdate);
+
 impl_update_config_accessors!(Update, {
-    fn api_headers(&self, auth_token: Option<&str>) -> Result<HeaderMap> {
-        api_headers(auth_token)
+    fn api_headers(&self, _auth_token: Option<&str>) -> Result<HeaderMap> {
+        api_headers()
     }
 });
 
@@ -450,7 +470,7 @@ fn releases_plan(
     auth_token: Option<&str>,
     stop_at: Option<&str>,
 ) -> Result<PageRequest<Release>> {
-    let headers = api_headers(auth_token)?;
+    let headers = api_headers()?;
     let auth = auth_token.map(str::to_owned);
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
@@ -492,12 +512,7 @@ fn release_array_page(
                 items.push(release);
             }
             let next = next_link(resp_headers).map(|next_url| {
-                release_array_page(
-                    next_url,
-                    api_headers_for(&auth),
-                    auth.clone(),
-                    stop_at.clone(),
-                )
+                release_array_page(next_url, api_headers_for(), auth.clone(), stop_at.clone())
             });
             Ok(Page {
                 items,
@@ -510,8 +525,8 @@ fn release_array_page(
 
 /// Transport-free plan to fetch a single release *object* (the `/releases/latest` and
 /// `/releases/tags/{ver}` endpoints), parsed via the private `ReleaseDto` into a one-item page.
-fn single_plan(url: String, auth_token: Option<&str>) -> Result<PageRequest<Release>> {
-    let headers = api_headers(auth_token)?;
+fn single_plan(url: String, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+    let headers = api_headers()?;
     Ok(PageRequest {
         url,
         headers,
@@ -524,12 +539,12 @@ fn single_plan(url: String, auth_token: Option<&str>) -> Result<PageRequest<Rele
     })
 }
 
-/// Build the github request headers, panicking only on an internal user-agent bug (never on the
-/// caller's auth token, which is validated). Used when rebuilding a next-page request inside the
-/// parser, where returning a `Result` is not possible — the auth token was already validated when
-/// the first page's headers were built, so this re-parse cannot fail for a caller-supplied token.
-fn api_headers_for(auth: &Option<String>) -> HeaderMap {
-    api_headers(auth.as_deref()).unwrap_or_default()
+/// Build the github request headers for a continuation page. Used when rebuilding a next-page
+/// request inside the parser closure, where returning a `Result` is not possible. Panics only on
+/// an internal user-agent bug (the header value is a static string that is always valid); a
+/// silent `.unwrap_or_default()` would drop the User-Agent on that failure path.
+fn api_headers_for() -> HeaderMap {
+    api_headers().expect("api_headers builds from static values")
 }
 
 #[cfg(feature = "async")]
@@ -581,10 +596,8 @@ impl crate::update::AsyncReleaseUpdate for Update {
 /// Build github's base request headers (its `rust/self-update` User-Agent). The Authorization
 /// header is no longer set here: the auth scheme/token is applied centrally by the shared
 /// [`apply_auth`](crate::backends::common::RequestConfig::apply_auth) on both the listing and
-/// download paths, which also honors a user `request_header(AUTHORIZATION, ..)` override. The
-/// `auth_token` argument is retained for signature compatibility but only gates whether an auth
-/// header *would* be added (it no longer is here).
-fn api_headers(_auth_token: Option<&str>) -> Result<header::HeaderMap> {
+/// download paths, which also honors a user `request_header(AUTHORIZATION, ..)` override.
+fn api_headers() -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::USER_AGENT,
@@ -609,11 +622,6 @@ mod tests {
     // The public config accessors (`api_headers`, `no_confirm`, `show_output`, ...) live on the
     // sealed `UpdateConfig` trait; bring it into scope so they resolve on the concrete `Update`.
     use crate::update::UpdateConfig;
-
-    // The async verbs are methods on the public sealed `AsyncReleaseUpdate` trait; bring it into
-    // scope so `upd.get_latest_release_async()` / `update_extended_async()` resolve in these tests.
-    #[cfg(feature = "async")]
-    use crate::update::AsyncReleaseUpdate;
 
     /// Test wrapper: drive the sans-io `releases_plan` through the sync `run_paginated` driver.
     /// `stop_at = None` => walk all pages (the unfiltered listing behavior).
@@ -1101,6 +1109,46 @@ mod tests {
             .unwrap();
         let status = upd.update_extended_async().await.unwrap();
         assert!(status.is_up_to_date(), "an older release means up-to-date");
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn is_update_available_async_reports_newest_newer_or_none() {
+        // Exercises the inherent `AsyncUpdate::is_update_available_async` verb emitted by
+        // `impl_async_update_verbs!`: from an older current version it returns the newest
+        // strictly-newer release; from a current version at/above the newest it returns `None`.
+        let body = r#"[{"tag_name":"v2.0.0","created_at":"2020-01-01T00:00:00Z","name":"v2.0.0","assets":[]},{"tag_name":"v0.9.0","created_at":"2020-01-01T00:00:00Z","name":"v0.9.0","assets":[]}]"#;
+        let mk = |cur: &'static str| {
+            let base = stub(move |_| {
+                vec![Resp {
+                    status: "200 OK",
+                    link: None,
+                    body: body.to_string(),
+                }]
+            });
+            super::Update::configure()
+                .repo_owner("o")
+                .repo_name("r")
+                .bin_name("app")
+                .current_version(cur)
+                .api_base_url(&base)
+                .build_async()
+                .unwrap()
+        };
+        let newer = mk("1.0.0").is_update_available_async().await.unwrap();
+        assert_eq!(
+            newer.map(|r| r.version().to_string()),
+            Some("2.0.0".to_string()),
+            "from 1.0.0 the 2.0.0 release is available"
+        );
+        assert!(
+            mk("2.0.0")
+                .is_update_available_async()
+                .await
+                .unwrap()
+                .is_none(),
+            "from 2.0.0 nothing newer => None"
+        );
     }
 
     #[test]
@@ -2116,7 +2164,7 @@ mod tests {
         .unwrap();
     }
 
-    // --- verify_keys builder setter and accessor -----------------------------------
+    // --- verifying_keys builder setter and accessor --------------------------------
 
     #[cfg(feature = "signatures")]
     #[test]
@@ -2133,14 +2181,103 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(
-            upd.verify_keys().len(),
+            upd.verifying_keys().len(),
             1,
-            "verify_keys() must return the key that was set"
+            "verifying_keys() must return the key that was set"
         );
         assert_eq!(
-            upd.verify_keys()[0],
+            upd.verifying_keys()[0],
             key_bytes,
             "returned key bytes must match what was supplied"
         );
+    }
+
+    // --- I2: api_headers takes no auth param; I1: api_headers_for uses .expect not .unwrap_or_default ---
+
+    #[test]
+    fn api_headers_takes_no_auth_param_and_sets_user_agent() {
+        // I2: api_headers() is now a zero-arg function (the unused _auth_token param was removed).
+        // This test calls it with no arguments -- it would fail to compile against the old
+        // `api_headers(_auth_token: Option<&str>)` signature.
+        // The User-Agent assertion ensures a broken implementation cannot silently pass.
+        let headers = super::api_headers().unwrap();
+        assert_eq!(
+            headers
+                .get(crate::http_client::header::USER_AGENT)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "rust/self-update",
+            "api_headers() must set the rust/self-update User-Agent"
+        );
+        assert!(
+            headers
+                .get(crate::http_client::header::AUTHORIZATION)
+                .is_none(),
+            "api_headers() must not set an Authorization header"
+        );
+    }
+
+    #[test]
+    fn api_headers_for_takes_no_param_and_sets_user_agent() {
+        // I1+I2: api_headers_for() is now a zero-arg function that uses .expect instead of
+        // .unwrap_or_default, so a failure surfaces rather than silently producing empty headers.
+        // This test calls it with no arguments -- it would fail to compile against the old
+        // `api_headers_for(auth: &Option<String>)` signature. The User-Agent assertion proves
+        // headers are not silently empty (as .unwrap_or_default() would give on a failure path).
+        let headers = super::api_headers_for();
+        assert_eq!(
+            headers
+                .get(crate::http_client::header::USER_AGENT)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "rust/self-update",
+            "api_headers_for() must return headers with the rust/self-update User-Agent set"
+        );
+    }
+
+    #[test]
+    fn continuation_page_user_agent_header_is_present() {
+        // I1: the continuation-page header builder must not silently drop the User-Agent.
+        // Drive a two-page fetch via stub_capturing and assert the second page's request carries
+        // the User-Agent header -- if api_headers_for() silently returned empty headers (the old
+        // .unwrap_or_default() path), the User-Agent would be absent on page 2.
+        let (base, captured) = stub_capturing(|base| {
+            vec![
+                Resp {
+                    status: "200 OK",
+                    link: Some(format!("{base}/releases?page=2")),
+                    body: release_json("v2.0.0"),
+                },
+                Resp {
+                    status: "200 OK",
+                    link: None,
+                    body: release_json("v1.0.0"),
+                },
+            ]
+        });
+        let releases = fetch_all_releases(
+            &format!("{base}/releases"),
+            None,
+            &crate::backends::common::RequestConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(releases.len(), 2, "both pages must be fetched");
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests.len(),
+            2,
+            "exactly two HTTP requests must be issued"
+        );
+        // Both requests must carry the User-Agent header.
+        for (i, req) in requests.iter().enumerate() {
+            assert!(
+                req.to_lowercase().contains("user-agent: rust/self-update"),
+                "page {} request is missing the User-Agent header:\n{}",
+                i + 1,
+                req
+            );
+        }
     }
 }

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -96,6 +96,11 @@ impl ReleaseListBuilder {
     ///
     /// Pass the instance host only (scheme + host, no trailing slash); the crate appends the
     /// `/api/v4/...` path itself. Do not include `/api/v4`.
+    ///
+    /// Note: this setter is deliberately different from the other backends. GitHub's
+    /// `api_base_url` wants the full API base URL (e.g. `https://api.github.com`); the S3
+    /// backend's `endpoint` is the S3 endpoint. GitLab is the instance host only because the
+    /// crate constructs the `/api/v4/projects/...` path itself (Decision 3).
     pub fn host(&mut self, url: impl Into<String>) -> &mut Self {
         self.host = url.into();
         self
@@ -271,6 +276,11 @@ impl UpdateBuilder {
     ///
     /// Pass the instance host only (scheme + host, no trailing slash); the crate appends the
     /// `/api/v4/...` path itself. Do not include `/api/v4`.
+    ///
+    /// Note: this setter is deliberately different from the other backends. GitHub's
+    /// `api_base_url` wants the full API base URL (e.g. `https://api.github.com`); the S3
+    /// backend's `endpoint` is the S3 endpoint. GitLab is the instance host only because the
+    /// crate constructs the `/api/v4/projects/...` path itself (Decision 3).
     pub fn host(&mut self, url: impl Into<String>) -> &mut Self {
         self.host = url.into();
         self
@@ -327,13 +337,14 @@ impl UpdateBuilder {
         self.build_update()
     }
 
-    /// Confirm config and create a ready-to-use `Update` for the async API (`update_async`).
+    /// Confirm config and create a ready-to-use [`AsyncUpdate`] for the async API (`update_async`).
     ///
-    /// Unlike [`build`](Self::build) this returns the concrete `Update` (not a
-    /// `Box<dyn ReleaseUpdate>`) so the inherent `*_async` methods are reachable.
+    /// Unlike [`build`](Self::build) this returns the distinct [`AsyncUpdate`] newtype, which exposes
+    /// only the inherent `*_async` verbs, so a stray blocking `.update()` on an async-built updater
+    /// is a compile error rather than a silent block of the executor.
     #[cfg(feature = "async")]
-    pub fn build_async(&self) -> Result<Update> {
-        self.build_update()
+    pub fn build_async(&self) -> Result<AsyncUpdate> {
+        Ok(AsyncUpdate(self.build_update()?))
     }
 }
 
@@ -413,9 +424,22 @@ impl ReleaseUpdate for Update {
 
 impl_sync_update_verbs!(Update);
 
+/// Async-only updater returned by [`UpdateBuilder::build_async`].
+///
+/// A newtype over the blocking [`Update`] that exposes **only** the inherent `*_async` verbs. Using
+/// it (instead of returning `Update` from `build_async`) makes a blocking call on an async-built
+/// updater — e.g. `build_async()?.update()` — a compile error, so the async executor cannot be
+/// silently blocked.
+#[cfg(feature = "async")]
+#[derive(Debug)]
+pub struct AsyncUpdate(Update);
+
+#[cfg(feature = "async")]
+impl_async_update_verbs!(AsyncUpdate);
+
 impl_update_config_accessors!(Update, {
-    fn api_headers(&self, auth_token: Option<&str>) -> Result<header::HeaderMap> {
-        api_headers(auth_token)
+    fn api_headers(&self, _auth_token: Option<&str>) -> Result<header::HeaderMap> {
+        api_headers()
     }
 });
 
@@ -439,7 +463,7 @@ fn releases_plan(
     auth_token: Option<&str>,
     stop_at: Option<&str>,
 ) -> Result<PageRequest<Release>> {
-    let headers = api_headers(auth_token)?;
+    let headers = api_headers()?;
     let auth = auth_token.map(str::to_owned);
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
@@ -482,7 +506,7 @@ fn release_array_page(
             let next = next_link(resp_headers).map(|next_url| {
                 release_array_page(
                     next_url,
-                    api_headers(auth.as_deref()).unwrap_or_default(),
+                    api_headers().expect("api_headers builds from static values"),
                     auth.clone(),
                     stop_at.clone(),
                 )
@@ -498,8 +522,8 @@ fn release_array_page(
 
 /// Transport-free plan for the newest release: GitLab has no `/releases/latest`, so the listing's
 /// first element (newest-first order) is "latest". Fetches just the first page (no pagination).
-fn newest_plan(base_url: &str, auth_token: Option<&str>) -> Result<PageRequest<Release>> {
-    let headers = api_headers(auth_token)?;
+fn newest_plan(base_url: &str, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+    let headers = api_headers()?;
     Ok(PageRequest {
         url: first_page_url(base_url),
         headers,
@@ -518,8 +542,8 @@ fn newest_plan(base_url: &str, auth_token: Option<&str>) -> Result<PageRequest<R
 }
 
 /// Transport-free plan to fetch a single release *object* (the `.../releases/{ver}` endpoint).
-fn single_plan(url: String, auth_token: Option<&str>) -> Result<PageRequest<Release>> {
-    let headers = api_headers(auth_token)?;
+fn single_plan(url: String, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+    let headers = api_headers()?;
     Ok(PageRequest {
         url,
         headers,
@@ -579,7 +603,7 @@ impl crate::update::AsyncReleaseUpdate for Update {
 /// Build gitlab's base request headers (its User-Agent). The Authorization header is applied
 /// centrally by the shared [`apply_auth`](crate::backends::common::RequestConfig::apply_auth) using
 /// gitlab's `Bearer` scheme on both the listing and download paths, honoring a user override.
-fn api_headers(_auth_token: Option<&str>) -> Result<header::HeaderMap> {
+fn api_headers() -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::USER_AGENT,
@@ -594,9 +618,6 @@ fn api_headers(_auth_token: Option<&str>) -> Result<header::HeaderMap> {
 mod tests {
     use super::Update;
     use crate::update::UpdateConfig;
-
-    #[cfg(feature = "async")]
-    use crate::update::AsyncReleaseUpdate;
 
     /// Async test wrapper over `releases_plan` + the async driver (unfiltered, all pages).
     #[cfg(feature = "async")]
@@ -729,9 +750,10 @@ mod tests {
     }
 
     /// Convenience: build a `gitlab::Update` (concrete type) pointed at the loopback stub.
-    /// Only available when the `async` feature is enabled (uses `build_async()`).
+    /// Only available when the `async` feature is enabled (uses `build_async()`, so the returned
+    /// [`AsyncUpdate`] exposes the inherent `*_async` verbs).
     #[cfg(feature = "async")]
-    fn gitlab_update(base: &str, current_version: &str) -> Update {
+    fn gitlab_update(base: &str, current_version: &str) -> super::AsyncUpdate {
         Update::configure()
             .host(base)
             .repo_owner("o")
@@ -1855,7 +1877,7 @@ mod tests {
 
     // --- the listing `Releases` from `ReleaseList::fetch` carries NO current
     // version, so `current_version()` is `None` and `is_update_available()` errors with EXACTLY
-    // `MissingField { field: "current_version" }` rather than silently answering. `into_vec()`
+    // `NoCurrentVersion` rather than silently answering. `into_vec()`
     // still recovers the underlying release vec.
     #[test]
     fn release_list_fetch_returns_listing_releases_without_current_version() {
@@ -1882,11 +1904,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on a listing must error with MissingField, got {:?}",
+            "is_update_available() on a listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let versions: Vec<String> = releases
@@ -1902,7 +1922,7 @@ mod tests {
     }
 
     // --- async sibling of `release_list_fetch_returns_listing_releases_without_current_version`:
-    // `ReleaseList::fetch_async` yields the same bare listing (no current version, MissingField
+    // `ReleaseList::fetch_async` yields the same bare listing (no current version, NoCurrentVersion
     // from `is_update_available()`, `into_vec()` recovers the releases).
     #[cfg(feature = "async")]
     #[tokio::test]
@@ -1931,11 +1951,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on a listing must error with MissingField, got {:?}",
+            "is_update_available() on a listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let versions: Vec<String> = releases
@@ -1977,6 +1995,74 @@ mod tests {
                 "missing tag_name must be Error::MissingAssetField {{ field: \"tag_name\" }}, got {:?}",
                 other
             ),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // I1/I2 guard tests
+    // -----------------------------------------------------------------------
+
+    // I2: `api_headers` takes no arguments after removing the vestigial `_auth_token` param.
+    // This test calls the private function with zero args; it would FAIL TO COMPILE on the old
+    // signature (`fn api_headers(_auth_token: Option<&str>) -> ...`) because that required one
+    // argument.
+    #[test]
+    fn api_headers_takes_no_args_and_sets_user_agent() {
+        let headers = super::api_headers().unwrap();
+        assert_eq!(
+            headers
+                .get(crate::http_client::header::USER_AGENT)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "rust-reqwest/self-update",
+            "api_headers() (no-arg form) must still set the User-Agent header"
+        );
+        assert!(
+            headers
+                .get(crate::http_client::header::AUTHORIZATION)
+                .is_none(),
+            "api_headers() must not bake an Authorization header; apply_auth handles that"
+        );
+    }
+
+    // I1: continuation pages must carry the correct User-Agent header, not empty headers.
+    // The test drives a two-page paginated fetch using the stub_capturing infrastructure, then
+    // inspects both raw requests to confirm the User-Agent is present. With the old
+    // `.unwrap_or_default()` (before I1), a failing `api_headers()` call on a continuation page
+    // would have silently produced an empty-headers page request; `.expect()` panics instead.
+    // In the normal (successful) case both old and new code send the header, so this is a
+    // regression guard that would catch any future regression where continuation page headers
+    // are built incorrectly.
+    #[test]
+    fn continuation_page_carries_user_agent_header() {
+        let (base, captured) = stub_capturing(|base| {
+            vec![
+                Resp {
+                    status: "200 OK",
+                    link: Some(format!("{base}/api/v4/projects/o%2Fr/releases?page=2")),
+                    body: release_json("v2.0.0"),
+                },
+                Resp {
+                    status: "200 OK",
+                    link: None,
+                    body: release_json("v1.0.0"),
+                },
+            ]
+        });
+        let upd = gl_update(&base, "0.1.0");
+        let _releases = upd.get_newer_releases().unwrap();
+
+        let reqs = captured.lock().unwrap();
+        assert_eq!(reqs.len(), 2, "both pages must have been requested");
+        for (i, req) in reqs.iter().enumerate() {
+            let lower = req.to_lowercase();
+            assert!(
+                lower.contains("user-agent: rust-reqwest/self-update"),
+                "page {} request must carry User-Agent header; got:\n{}",
+                i + 1,
+                req
+            );
         }
     }
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -56,6 +56,12 @@ pub(crate) fn find_rel_next_link(link_str: &str) -> Option<&str> {
 /// against pathological release histories.
 pub(crate) const MAX_RELEASE_PAGES: usize = 100;
 
+/// Maximum number of bytes buffered for a single listing-page body. A per-page COUNT bound
+/// ([`MAX_RELEASE_PAGES`]) was already present; this per-page SIZE bound prevents a pathological
+/// or misconfigured endpoint from forcing unbounded memory use. Real GitHub/GitLab/Gitea release
+/// listing pages with 100 entries and many assets are well under 1 MiB; 4 MiB is a generous cap.
+pub(crate) const MAX_LISTING_BODY_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
+
 /// A sans-io description of a single page request: *what* to fetch (`url` + `headers`) and *how*
 /// to parse the response body into items, the next page (if any), and an early-stop signal — with
 /// no transport. The two drivers ([`run_paginated`] / [`run_paginated_async`]) perform the IO by
@@ -113,8 +119,23 @@ pub(crate) fn run_paginated<T>(
         let resp = send(&url, headers, config)?;
         let resp_headers = resp.headers().clone();
         let mut body = Vec::new();
-        let mut reader = resp.body();
-        std::io::Read::read_to_end(&mut reader, &mut body)?;
+        let reader = resp.body();
+        // S5: cap the per-page body size so a malicious or misconfigured endpoint cannot force
+        // unbounded memory use. Read one byte past the cap to distinguish "exactly at the cap"
+        // (fine) from "over the cap" (error).
+        let mut limited = {
+            use std::io::Read as _;
+            reader.take((MAX_LISTING_BODY_BYTES + 1) as u64)
+        };
+        std::io::Read::read_to_end(&mut limited, &mut body)?;
+        if body.len() > MAX_LISTING_BODY_BYTES {
+            return Err(Error::InvalidResponse {
+                source: Box::new(crate::errors::MessageError(format!(
+                    "listing page body exceeded the {MAX_LISTING_BODY_BYTES}-byte cap; \
+                     real release listing pages are much smaller"
+                ))),
+            });
+        }
         let page = parse(&body, &resp_headers)?;
         out.extend(page.items);
         pages += 1;
@@ -162,6 +183,15 @@ pub(crate) async fn run_paginated_async<T>(
         let mut body = Vec::new();
         while let Some(chunk) = stream.next().await {
             body.extend_from_slice(&chunk?);
+            // S5: cap the per-page body size (same bound as the sync driver).
+            if body.len() > MAX_LISTING_BODY_BYTES {
+                return Err(Error::InvalidResponse {
+                    source: Box::new(crate::errors::MessageError(format!(
+                        "listing page body exceeded the {MAX_LISTING_BODY_BYTES}-byte cap; \
+                         real release listing pages are much smaller"
+                    ))),
+                });
+            }
         }
         let page = parse(&body, &resp_headers)?;
         out.extend(page.items);
@@ -213,8 +243,9 @@ pub(crate) fn retry_backoff_ms(
     base: std::time::Duration,
     max: std::time::Duration,
 ) -> u64 {
-    let base_ms = base.as_millis() as u64;
-    let max_ms = max.as_millis() as u64;
+    // I8: as_millis() returns u128; saturate to u64::MAX rather than silently truncating.
+    let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    let max_ms = u64::try_from(max.as_millis()).unwrap_or(u64::MAX);
     // Double `base` `attempt` times with saturation, then clamp to `max`.
     let doubled = (0..attempt).fold(base_ms, |acc, _| acc.saturating_mul(2));
     doubled.min(max_ms)
@@ -295,6 +326,11 @@ pub(crate) fn send(
     // at another host does not receive it.
     config.apply_auth(url, &mut base)?;
     for (name, value) in &config.headers {
+        // S2: gate a user-supplied Authorization header with the same host check that guards the
+        // backend-derived token; drop it for any host that is not in the allow list.
+        if name == http_client::header::AUTHORIZATION && !config.auth_allowed_for(url) {
+            continue;
+        }
         base.insert(name.clone(), value.clone());
     }
     // Dispatch through the injected client if present, else the crate's default per-call client.
@@ -312,7 +348,9 @@ pub(crate) fn send(
         config.retry_max_delay,
         || client.get(url, &base, config.timeout),
         |e, backoff| {
-            log::warn!("self_update: request to {url} failed ({e}); retrying in {backoff}ms");
+            // S1: redact presigned-URL credentials before logging.
+            let safe_url = crate::errors::redact_url(url);
+            log::warn!("self_update: request to {safe_url} failed ({e}); retrying in {backoff}ms");
             std::thread::sleep(std::time::Duration::from_millis(backoff));
         },
     )
@@ -328,6 +366,10 @@ pub(crate) async fn send_async(
 ) -> Result<Box<dyn http_client::AsyncHttpResponse>> {
     config.apply_auth(url, &mut base)?;
     for (name, value) in &config.headers {
+        // S2: same host gate as the sync `send` path (see comment there).
+        if name == http_client::header::AUTHORIZATION && !config.auth_allowed_for(url) {
+            continue;
+        }
         base.insert(name.clone(), value.clone());
     }
     let default;
@@ -344,7 +386,9 @@ pub(crate) async fn send_async(
         config.retry_max_delay,
         || client.get(url, &base, config.timeout),
         |e, backoff| {
-            log::warn!("self_update: request to {url} failed ({e}); retrying in {backoff}ms");
+            // S1: redact presigned-URL credentials before logging.
+            let safe_url = crate::errors::redact_url(url);
+            log::warn!("self_update: request to {safe_url} failed ({e}); retrying in {backoff}ms");
         },
         |backoff| tokio::time::sleep(std::time::Duration::from_millis(backoff)),
     )
@@ -1071,7 +1115,9 @@ mod test {
         use crate::backends::common::AuthScheme;
         use crate::http_client::header::AUTHORIZATION;
         // A backend token is configured AND the user supplies their own Authorization via
-        // `request_header` (i.e. config.headers). The user override must win on the listing path.
+        // `request_header` (i.e. config.headers). The user override must win on the listing path
+        // when the URL's host is in the allow list (S2: the same host gate applies to both the
+        // derived token and the user-supplied Authorization).
         let (base, captured) = auth_capture_stub();
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, "Bearer user-override".parse().unwrap());
@@ -1079,6 +1125,8 @@ mod test {
             auth_scheme: AuthScheme::Token,
             auth_token: Some("secret".to_string()),
             headers,
+            // Allow the stub's loopback host so the user Authorization passes the S2 gate.
+            auth_base_host: crate::backends::common::host_of(&base),
             ..Default::default()
         };
         let _ = crate::backends::send(&base, HeaderMap::new(), &config).unwrap();
@@ -1136,6 +1184,217 @@ mod test {
         assert_eq!(
             next_link(&headers),
             Some("https://api.example.com/r?page=2".to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // I8: retry_backoff_ms safe u128->u64 cast
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn retry_backoff_ms_saturates_for_huge_duration() {
+        use crate::backends::retry_backoff_ms;
+        use std::time::Duration;
+        // Duration::from_secs(u64::MAX) has as_millis() >> u64::MAX; the old `as u64` cast
+        // silently truncated. The fix (u64::try_from(..).unwrap_or(u64::MAX)) must saturate.
+        let huge = Duration::from_secs(u64::MAX);
+        // Both base and max are huge; regardless of attempt, the result must be u64::MAX.
+        assert_eq!(
+            retry_backoff_ms(0, huge, huge),
+            u64::MAX,
+            "a Duration::from_secs(u64::MAX) base must not truncate: expected u64::MAX"
+        );
+        // A clamp against a huge max: the doubled base is still huge, capped to the huge max.
+        assert_eq!(
+            retry_backoff_ms(5, huge, huge),
+            u64::MAX,
+            "a huge duration at a non-zero attempt must also saturate to u64::MAX"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // S1: retry log lines must not leak presigned-URL credentials
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn retry_log_redacts_amz_signature_in_presigned_url() {
+        // The retry on_retry closure in `send`/`send_async` must call `crate::errors::redact_url`
+        // before formatting the log message (S1 fix). Construct the exact string the closure
+        // produces and assert no raw credential value appears.
+        let presigned_url = "https://bucket.s3.amazonaws.com/app.tar.gz\
+            ?X-Amz-Credential=AKIAEXAMPLE\
+            &X-Amz-Expires=300\
+            &X-Amz-Signature=s3cr3tsig\
+            &X-Amz-SignedHeaders=host";
+        let safe = crate::errors::redact_url(presigned_url);
+        // Format the message exactly as the on_retry closure does:
+        let log_line = format!("self_update: request to {safe} failed (err); retrying in 100ms");
+        assert!(
+            !log_line.contains("s3cr3tsig"),
+            "retry log line must not contain the raw X-Amz-Signature value: {log_line}"
+        );
+        assert!(
+            log_line.contains("X-Amz-Signature=REDACTED"),
+            "the parameter key must still appear as REDACTED in the log: {log_line}"
+        );
+        // Confirm that WITHOUT redaction the secret would have appeared (documents the fix intent).
+        let without_fix =
+            format!("self_update: request to {presigned_url} failed (err); retrying in 100ms");
+        assert!(
+            without_fix.contains("s3cr3tsig"),
+            "sanity: the unfixed format string DOES contain the raw signature"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // S2: user-supplied Authorization is gated by the same host check as the
+    //     backend-derived token
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn send_drops_user_authorization_for_disallowed_host() {
+        // A user-supplied Authorization in config.headers must be dropped for a host that is not
+        // in the allow list (S2 fix). auth_base_host=None means no host is allowed.
+        use crate::http_client::header::AUTHORIZATION;
+        let (base, captured) = auth_capture_stub();
+        let mut extra = HeaderMap::new();
+        extra.insert(AUTHORIZATION, "Bearer user-token".parse().unwrap());
+        let config = RequestConfig {
+            headers: extra,
+            auth_base_host: None, // no host allowed → user Authorization must be dropped
+            ..Default::default()
+        };
+        let _ = crate::backends::send(&base, HeaderMap::new(), &config).unwrap();
+        let lines = captured.lock().unwrap().clone();
+        assert_eq!(
+            captured_authorization(&lines),
+            None,
+            "user Authorization must be dropped when auth_base_host is None (disallowed host)"
+        );
+    }
+
+    #[test]
+    fn send_keeps_user_authorization_for_allowed_host() {
+        // A user-supplied Authorization must reach the server when the URL's host is in the allow
+        // list (S2 regression guard: the gate must not over-restrict).
+        use crate::http_client::header::AUTHORIZATION;
+        let (base, captured) = auth_capture_stub();
+        let stub_host = crate::backends::common::host_of(&base);
+        let mut extra = HeaderMap::new();
+        extra.insert(AUTHORIZATION, "Bearer user-token".parse().unwrap());
+        let config = RequestConfig {
+            headers: extra,
+            auth_base_host: stub_host,
+            ..Default::default()
+        };
+        let _ = crate::backends::send(&base, HeaderMap::new(), &config).unwrap();
+        let lines = captured.lock().unwrap().clone();
+        assert_eq!(
+            captured_authorization(&lines),
+            Some("Bearer user-token".to_string()),
+            "user Authorization must be forwarded when the host is in the allow list"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // S5: per-page body size cap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn run_paginated_errors_when_body_exceeds_cap() {
+        use crate::backends::MAX_LISTING_BODY_BYTES;
+        use std::io::{Read as _, Write as _};
+        use std::net::TcpListener;
+
+        // A body one byte over MAX_LISTING_BODY_BYTES must produce Error::InvalidResponse
+        // before parse is ever called (S5: per-page body size cap).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let over_cap = MAX_LISTING_BODY_BYTES + 1;
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let hdr = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {over_cap}\r\nConnection: close\r\n\r\n"
+                );
+                let _ = stream.write_all(hdr.as_bytes());
+                let chunk = vec![b'x'; 8192];
+                let mut remaining = over_cap;
+                while remaining > 0 {
+                    let n = remaining.min(chunk.len());
+                    let _ = stream.write_all(&chunk[..n]);
+                    remaining -= n;
+                }
+                let _ = stream.flush();
+            }
+        });
+        let req = PageRequest::<i32> {
+            url: format!("{base}/page"),
+            headers: HeaderMap::new(),
+            // Without the S5 fix, parse would be called with a huge body and return Aborted —
+            // the assertion below would then fail (Aborted != InvalidResponse).
+            parse: Box::new(|_body, _headers| Err(crate::errors::Error::Aborted)),
+        };
+        let res = crate::backends::run_paginated(req, &RequestConfig::default());
+        assert!(
+            matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
+            "a body over the cap must error with InvalidResponse, got: {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn run_paginated_normal_body_is_not_capped() {
+        // A body well under MAX_LISTING_BODY_BYTES must parse normally (S5 regression guard).
+        let (base, _) = linked_stub(vec![(None, "10,20,30")]);
+        let got = crate::backends::run_paginated(
+            int_page(format!("{base}/page")),
+            &RequestConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(got, vec![10, 20, 30]);
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn run_paginated_async_errors_when_body_exceeds_cap() {
+        use crate::backends::MAX_LISTING_BODY_BYTES;
+        use std::io::{Read as _, Write as _};
+        use std::net::TcpListener;
+
+        // Async variant of run_paginated_errors_when_body_exceeds_cap.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let over_cap = MAX_LISTING_BODY_BYTES + 1;
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let hdr = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {over_cap}\r\nConnection: close\r\n\r\n"
+                );
+                let _ = stream.write_all(hdr.as_bytes());
+                let chunk = vec![b'x'; 8192];
+                let mut remaining = over_cap;
+                while remaining > 0 {
+                    let n = remaining.min(chunk.len());
+                    let _ = stream.write_all(&chunk[..n]);
+                    remaining -= n;
+                }
+                let _ = stream.flush();
+            }
+        });
+        let req = PageRequest::<i32> {
+            url: format!("{base}/page"),
+            headers: HeaderMap::new(),
+            parse: Box::new(|_body, _headers| Err(crate::errors::Error::Aborted)),
+        };
+        let res = crate::backends::run_paginated_async(req, &RequestConfig::default()).await;
+        assert!(
+            matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
+            "async: a body over the cap must error with InvalidResponse, got: {:?}",
+            res
         );
     }
 }

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -13,7 +13,18 @@ use quick_xml::Reader;
 use quick_xml::events::Event;
 use regex::Regex;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::time::Duration;
+
+/// Filename -> `(name, version)` matcher for S3 asset keys, e.g. `myapp-v1.2.3-x86_64-linux`.
+///
+/// Hoisted to a process-wide `LazyLock` so it is compiled once rather than on every listing page
+/// parsed by [`parse_s3_response`]. The pattern is a compile-time literal and is known-valid, so
+/// `Regex::new` cannot fail here.
+static ASSET_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?P<prefix>.*/)*(?P<name>.+)-[v]{0,1}(?P<version>\d+\.\d+\.\d+)-.+")
+        .expect("the S3 asset-key regex is a valid compile-time literal")
+});
 
 /// Default number of items to retrieve per S3 listing request. The S3 ListObjectsV2 API caps a
 /// single request at 1000 keys.
@@ -158,7 +169,12 @@ impl ReleaseListBuilder {
         self
     }
 
-    /// Set the end point
+    /// Set the S3 endpoint (the storage endpoint the bucket listing is issued against).
+    ///
+    /// Note: this `endpoint` is the *S3 storage endpoint*, a deliberately different notion from the
+    /// server URL of the other backends. The github backend uses `api_base_url` (the full API base
+    /// URL) and the gitlab/gitea backends use `host` (the instance host); s3's `endpoint` is neither
+    /// of those. The differing names reflect that semantic divergence rather than an inconsistency.
     pub fn endpoint(&mut self, endpoint: impl Into<Endpoint>) -> &mut Self {
         self.endpoint = endpoint.into();
         self
@@ -362,7 +378,12 @@ impl UpdateBuilder {
         self
     }
 
-    /// Set the end point
+    /// Set the S3 endpoint (the storage endpoint the bucket listing is issued against).
+    ///
+    /// Note: this `endpoint` is the *S3 storage endpoint*, a deliberately different notion from the
+    /// server URL of the other backends. The github backend uses `api_base_url` (the full API base
+    /// URL) and the gitlab/gitea backends use `host` (the instance host); s3's `endpoint` is neither
+    /// of those. The differing names reflect that semantic divergence rather than an inconsistency.
     pub fn endpoint(&mut self, endpoint: impl Into<Endpoint>) -> &mut Self {
         self.endpoint = endpoint.into();
         self
@@ -434,13 +455,14 @@ impl UpdateBuilder {
         self.build_update()
     }
 
-    /// Confirm config and create a ready-to-use `Update` for the async API (`update_async`).
+    /// Confirm config and create a ready-to-use [`AsyncUpdate`] for the async API (`update_async`).
     ///
-    /// Unlike [`build`](Self::build) this returns the concrete `Update` (not a
-    /// `Box<dyn ReleaseUpdate>`) so the inherent `*_async` methods are reachable.
+    /// Unlike [`build`](Self::build) this returns the distinct [`AsyncUpdate`] newtype, which exposes
+    /// only the inherent `*_async` verbs, so a stray blocking `.update()` on an async-built updater
+    /// is a compile error rather than a silent block of the executor.
     #[cfg(feature = "async")]
-    pub fn build_async(&self) -> Result<Update> {
-        self.build_update()
+    pub fn build_async(&self) -> Result<AsyncUpdate> {
+        Ok(AsyncUpdate(self.build_update()?))
     }
 }
 
@@ -521,7 +543,11 @@ fn sort_newer(releases: Vec<Release>, current_version: &str) -> Vec<Release> {
 }
 
 /// Find the release matching an explicit version. Shared by the sync and async paths.
+///
+/// Stored versions are bare semver (the parser strips any leading `v`), so a requested tag is
+/// normalized the same way before comparison: `.release_tag("v1.2.3")` matches a stored `1.2.3`.
 fn find_version(releases: &[Release], ver: &str) -> Result<Release> {
+    let ver = ver.trim_start_matches('v');
     match releases.iter().find(|x| x.version() == ver) {
         Some(r) => Ok(r.clone()),
         None => Err(Error::NoReleaseFound { target: None }),
@@ -549,6 +575,19 @@ impl ReleaseUpdate for Update {
 }
 
 impl_sync_update_verbs!(Update);
+
+/// Async-only updater returned by [`UpdateBuilder::build_async`].
+///
+/// A newtype over the blocking [`Update`] that exposes **only** the inherent `*_async` verbs. Using
+/// it (instead of returning `Update` from `build_async`) makes a blocking call on an async-built
+/// updater — e.g. `build_async()?.update()` — a compile error, so the async executor cannot be
+/// silently blocked.
+#[cfg(feature = "async")]
+#[derive(Debug)]
+pub struct AsyncUpdate(Update);
+
+#[cfg(feature = "async")]
+impl_async_update_verbs!(AsyncUpdate);
 
 impl_update_config_accessors!(Update);
 
@@ -1328,7 +1367,7 @@ fn build_s3_api_url(
             download_base_url, max_keys, prefix, continuation
         ),
         Endpoint::GCS => format!(
-            "{}?max-keys={}{}{}",
+            "{}?list-type=2&max-keys={}{}{}",
             download_base_url, max_keys, prefix, continuation
         ),
     };
@@ -1471,11 +1510,9 @@ fn parse_s3_response<R: std::io::BufRead>(
     let mut current_release: Option<Release> = None;
     let mut is_truncated = false;
     let mut next_continuation_token: Option<String> = None;
-    let regex =
-        Regex::new(r"(?i)(?P<prefix>.*/)*(?P<name>.+)-[v]{0,1}(?P<version>\d+\.\d+\.\d+)-.+")
-            .map_err(|err| Error::InvalidResponse {
-                source: Box::new(err),
-            })?;
+    // The filename matcher is compiled once, process-wide (see `ASSET_KEY_REGEX`), rather than on
+    // every page parsed.
+    let regex = &*ASSET_KEY_REGEX;
 
     // inspecting each XML element we populate our releases list
     let mut buf = Vec::new();
@@ -1592,9 +1629,6 @@ mod tests {
     use super::Update;
     use crate::update::{Release, UpdateConfig};
     use std::time::Duration;
-
-    #[cfg(feature = "async")]
-    use crate::update::AsyncReleaseUpdate;
 
     // ---------------------------------------------------------------------------
     // Helpers shared between sync XML-parse tests and async stub tests
@@ -1898,6 +1932,39 @@ mod tests {
     }
 
     #[test]
+    fn parse_s3_response_extracts_continuation_token_for_gcs_multipage_listing() {
+        // C3 regression: GCS listings must page. When the first-page body is flagged truncated and
+        // carries a `<NextContinuationToken>` (which GCS emits only under `list-type=2`), the parser
+        // must surface that token so the driver fetches the next page. This drives the raw
+        // `super::parse_s3_response` (the test wrapper drops the token) and asserts BOTH the token is
+        // returned AND the first page's release is parsed, so pagination continues rather than
+        // silently dropping later pages.
+        let page1 = truncated_list_bucket_xml(&["myapp-1.0.0-x86_64-linux"], "GCS-TOKEN-PAGE-2");
+        let (releases, next_token) = super::parse_s3_response(
+            page1.as_bytes(),
+            "https://storage.googleapis.com/gbucket/",
+            #[cfg(feature = "s3-auth")]
+            &None,
+            #[cfg(feature = "s3-auth")]
+            Duration::from_secs(super::DEFAULT_SIGNATURE_TTL_SECS),
+            #[cfg(feature = "s3-auth")]
+            &None,
+        )
+        .unwrap();
+        assert_eq!(
+            next_token.as_deref(),
+            Some("GCS-TOKEN-PAGE-2"),
+            "a truncated first page must surface its NextContinuationToken so pagination continues"
+        );
+        assert_eq!(
+            releases.len(),
+            1,
+            "the first page's release is still parsed alongside the continuation token"
+        );
+        assert_eq!(releases[0].version(), "1.0.0");
+    }
+
+    #[test]
     fn add_to_releases_list_skips_entries_with_empty_name_or_version() {
         // `add_to_releases_list` must silently drop a release whose name or version is empty,
         // matching the `if !rel.version().is_empty() && !rel.name.is_empty()` guard.
@@ -1961,7 +2028,7 @@ mod tests {
     /// Build a `fetch_releases_from_s3_async`-ready `Update` whose `Endpoint::Generic` points at
     /// the stub base URL. The Generic endpoint does not require a region.
     #[cfg(feature = "async")]
-    fn s3_update(base_url: &str, current_version: &str) -> Update {
+    fn s3_update(base_url: &str, current_version: &str) -> super::AsyncUpdate {
         Update::configure()
             .endpoint(super::Endpoint::Generic(base_url.to_owned()))
             .bucket_name("test-bucket")
@@ -2360,7 +2427,7 @@ mod tests {
 
     // --- `ReleaseList::fetch` returns a listing `Releases` with NO current version,
     // so `current_version()` is `None` and `is_update_available()` errors with EXACTLY
-    // `MissingField { field: "current_version" }`. `into_vec()` recovers the parsed release vec.
+    // `NoCurrentVersion`. `into_vec()` recovers the parsed release vec.
     #[test]
     fn release_list_fetch_returns_listing_releases_without_current_version() {
         let xml = list_bucket_xml(&["myapp-2.0.0-x86_64-linux", "myapp-1.0.0-x86_64-linux"]);
@@ -2383,11 +2450,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on an s3 listing must error with MissingField, got {:?}",
+            "is_update_available() on an s3 listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let mut versions: Vec<String> = releases
@@ -2404,7 +2469,7 @@ mod tests {
     }
 
     // --- async sibling of `release_list_fetch_returns_listing_releases_without_current_version`:
-    // `ReleaseList::fetch_async` yields the same bare listing (no current version, MissingField
+    // `ReleaseList::fetch_async` yields the same bare listing (no current version, NoCurrentVersion
     // from `is_update_available()`, `into_vec()` recovers the releases).
     #[cfg(feature = "async")]
     #[tokio::test]
@@ -2430,11 +2495,9 @@ mod tests {
         assert!(
             matches!(
                 releases.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "is_update_available() on an s3 listing must error with MissingField, got {:?}",
+            "is_update_available() on an s3 listing must error with NoCurrentVersion, got {:?}",
             releases.is_update_available()
         );
         let mut versions: Vec<String> = releases
@@ -2913,6 +2976,29 @@ mod tests {
         assert!(super::find_version(&releases, "9.9.9").is_err());
     }
 
+    #[test]
+    fn find_version_matches_v_prefixed_release_tag() {
+        // Regression (I5): stored versions are bare semver (the S3 key parser strips any leading
+        // `v`), so a `.release_tag("v1.2.3")` must still resolve. `find_version` normalizes the
+        // requested tag by trimming a leading `v` before comparing; both the `v`-prefixed and the
+        // bare form must select the same release, and a genuinely-absent tag still errors.
+        let releases = [rel("1.0.0"), rel("1.2.3"), rel("2.0.0")];
+        assert_eq!(
+            super::find_version(&releases, "v1.2.3").unwrap().version(),
+            "1.2.3",
+            "a v-prefixed release_tag must match the bare stored semver"
+        );
+        assert_eq!(
+            super::find_version(&releases, "1.2.3").unwrap().version(),
+            "1.2.3",
+            "the bare form must keep working"
+        );
+        assert!(
+            super::find_version(&releases, "v9.9.9").is_err(),
+            "a v-prefixed tag with no matching release still errors"
+        );
+    }
+
     fn configured() -> Update {
         Update::configure()
             .bucket_name("bucket")
@@ -3012,15 +3098,21 @@ mod tests {
     }
 
     #[test]
-    fn build_s3_api_url_gcs_ignores_region_and_uses_maxkeys_only() {
-        // Endpoint::GCS targets `storage.googleapis.com/<bucket>/`, does NOT embed a region, and
-        // its listing query is `max-keys` only (no `list-type=2`, which is S3-specific).
+    fn build_s3_api_url_gcs_ignores_region_but_uses_list_type_2() {
+        // Endpoint::GCS targets `storage.googleapis.com/<bucket>/` and does NOT embed a region.
+        // GCS's XML API supports the S3 ListObjectsV2 `list-type=2` param, which yields
+        // `<NextContinuationToken>` pagination the parser follows; without it GCS falls back to V1
+        // `<NextMarker>` pagination the parser ignores, silently dropping later pages. So the GCS
+        // listing query must carry `list-type=2`, matching the S3/DualStack/DO/Generic arms.
         let (base, url) = api_url(super::Endpoint::GCS, "gbucket", None, None).unwrap();
         assert_eq!(base, "https://storage.googleapis.com/gbucket/");
-        assert_eq!(url, "https://storage.googleapis.com/gbucket/?max-keys=1000");
+        assert_eq!(
+            url,
+            "https://storage.googleapis.com/gbucket/?list-type=2&max-keys=1000"
+        );
         assert!(
-            !url.contains("list-type=2"),
-            "GCS listing must not use the S3-only list-type=2 param"
+            url.contains("list-type=2"),
+            "GCS listing must request list-type=2 so V2 NextContinuationToken pagination is used"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -122,6 +122,14 @@ pub enum Error {
         /// The name of the missing required field.
         field: &'static str,
     },
+    /// A bare release listing ([`ReleaseList::fetch`](crate::backends)) carries no current version,
+    /// so [`Releases::is_update_available`](crate::update::Releases::is_update_available) has nothing
+    /// to compare its releases against.
+    ///
+    /// Distinct from [`MissingField`](Error::MissingField): there is no builder field to set. Use
+    /// `Update::is_update_available` on a configured updater (which knows its current version)
+    /// instead.
+    NoCurrentVersion,
     /// An HTTP header supplied to the builder (`request_header` / `header`) was not valid.
     ///
     /// Wraps the underlying header-conversion error, surfaced via [`std::error::Error::source`].
@@ -330,6 +338,11 @@ impl std::fmt::Display for Error {
             }
             InvalidResponse { source } => write!(f, "ReleaseError: invalid response: {}", source),
             MissingField { field } => write!(f, "ConfigError: `{}` required", field),
+            NoCurrentVersion => write!(
+                f,
+                "ReleaseError: this Releases has no current_version to compare against; use \
+                 `Update::is_update_available` for a configured updater"
+            ),
             InvalidHeader { source } => write!(f, "ConfigError: invalid HTTP header: {}", source),
             InvalidAuthToken { source } => {
                 write!(f, "ConfigError: failed to parse auth token: {}", source)
@@ -1136,6 +1149,28 @@ mod tests {
             "MissingField carries no source, got {:?}",
             err.source()
         );
+        assert_eq!(err.http_status(), None);
+        assert_eq!(err.url(), None);
+    }
+
+    // `NoCurrentVersion` is a distinct, self-describing variant (not `MissingField`): its Display
+    // names the missing current_version and points at `Update::is_update_available`, carries no
+    // source, and exposes no http_status()/url(). Pins that the bare-listing precheck error is not
+    // the misleading builder-field message.
+    #[test]
+    fn no_current_version_display_and_no_source() {
+        let err = Error::NoCurrentVersion;
+        let shown = err.to_string();
+        assert_eq!(
+            shown,
+            "ReleaseError: this Releases has no current_version to compare against; use \
+             `Update::is_update_available` for a configured updater"
+        );
+        assert!(
+            !matches!(err, Error::MissingField { .. }),
+            "NoCurrentVersion must be distinct from MissingField"
+        );
+        assert!(err.source().is_none(), "NoCurrentVersion carries no source");
         assert_eq!(err.http_status(), None);
         assert_eq!(err.url(), None);
     }

--- a/src/http_client/ureq.rs
+++ b/src/http_client/ureq.rs
@@ -55,7 +55,10 @@ fn build_call_agent(
     #[cfg(not(feature = "rustls"))]
     let provider = TlsProvider::NativeTls;
 
+    #[cfg(any(not(feature = "reqwest"), test))]
     let mut tls = TlsConfig::builder().provider(provider);
+    #[cfg(all(feature = "reqwest", not(test)))]
+    let tls = TlsConfig::builder().provider(provider);
     #[cfg(any(not(feature = "reqwest"), test))]
     if let Some(certs) = root_certs {
         tls = tls.root_certs(ureq::tls::RootCerts::Specific(certs));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ The following are opt-in; activate the one(s) your release files need:
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;
 * `checksums`: verify a downloaded artifact against a known SHA-256/SHA-512 checksum (e.g. from a `SHA256SUMS` file) before installing it;
-* `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest handles async, ureq handles sync); see [Async](#async) below.
+* `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest serves the async path, and the sync API prefers reqwest when both are present); see [Async](#async) below.
 
 `github` is the only backend in the default feature set. The S3 backend requires the `s3` feature; `s3-auth` implies `s3`. `gitlab` and `gitea` each require their own feature.
 
@@ -321,19 +321,20 @@ fn update() -> Result<(), Box<dyn std::error::Error>> {
 ### Async
 
 With the `async` feature, every built-in backend's `Update` builder gains a `build_async()` that
-returns a concrete `Update` implementing the public sealed [`AsyncReleaseUpdate`] trait, with async
-(`*_async`) verbs — `update_async()`, `update_extended_async()`, `get_latest_release_async()`,
-`get_newer_releases_async()`, and `get_release_version_async()` — so a `tokio` application can
-update without wrapping the blocking calls in `spawn_blocking`. Bring [`AsyncReleaseUpdate`] into
-scope to call the verbs. The blocking API is unchanged; the async path is purely additive. It is
-**tokio-only and requires `reqwest`** -- ureq and reqwest can coexist (reqwest handles async, ureq
-handles sync); the only invalid configuration is `async` without `reqwest`.
-Network IO becomes async, and the extract/replace tail runs on `tokio::task::spawn_blocking` so it
-does not block the executor.
+returns a distinct `AsyncUpdate` wrapper (one per backend). Its async (`*_async`) verbs —
+`update_async()`, `update_extended_async()`, `get_latest_release_async()`,
+`get_newer_releases_async()`, `get_release_version_async()`, and `is_update_available_async()` — are
+**inherent methods** on that wrapper, so a `tokio` application can update without wrapping the
+blocking calls in `spawn_blocking` and without importing any trait. Crucially, the `AsyncUpdate`
+wrapper does **not** expose the blocking verbs: calling `.update()` on an async-built updater is a
+compile error, so the old footgun of accidentally running a blocking update from an async context
+is gone. The blocking API is unchanged; the async path is purely additive. It is **tokio-only and
+requires `reqwest`** -- ureq and reqwest can coexist (reqwest serves the async path, and the sync
+API prefers reqwest when both are present); the only invalid configuration is `async` without
+`reqwest`. Network IO becomes async, and the extract/replace tail runs on
+`tokio::task::spawn_blocking` so it does not block the executor.
 
 ```rust
-# #[cfg(feature = "async")]
-use self_update::AsyncReleaseUpdate;
 # #[cfg(feature = "async")]
 async fn update() -> Result<(), Box<dyn std::error::Error>> {
     let status = self_update::backends::github::Update::configure()
@@ -345,6 +346,27 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
         .update_async()
         .await?;
     println!("Update status: `{}`!", status.version());
+    Ok(())
+}
+```
+
+The `AsyncUpdate` wrapper exposes only the `*_async` verbs; the blocking `update()` is not a method
+on it, so accidentally calling it from async code does not compile. The following block is
+`compile_fail` for exactly that reason — `update` is not a method on the async wrapper (this block
+is intentionally not feature-gated: gating it behind `cfg(feature = "async")` would make it an empty,
+successfully-compiling doctest in the crate's no-`async` test lanes, which a `compile_fail` block
+must never do):
+
+```rust,compile_fail
+fn wont_compile() -> Result<(), Box<dyn std::error::Error>> {
+    let updater = self_update::backends::github::Update::configure()
+        .repo_owner("jaemk")
+        .repo_name("self_update")
+        .bin_name("github")
+        .current_version(self_update::cargo_crate_version!())
+        .build_async()?;
+    // `update()` is the BLOCKING verb; it is not exposed on the async `AsyncUpdate` wrapper.
+    updater.update()?;
     Ok(())
 }
 ```
@@ -363,8 +385,8 @@ need a separate dependency to name the type. (Since the transport is a runtime t
 and `ureq` are no longer mutually exclusive — both can be enabled, and the sync API prefers reqwest
 when both are present.) For test doubles or fully custom transport, inject any type that implements
 the object-safe trait directly via `.http_client(Arc<dyn HttpClient>)` (sync) or
-`.http_client_async(Arc<dyn AsyncHttpClient>)` (async); see the [`self_update::http_client`] module
-for the trait definitions.
+`.http_client_async(Arc<dyn AsyncHttpClient>)` (async); see the [`http_client`](crate::http_client)
+module for the trait definitions.
 
 When you inject a client, `.request_header()` still applies, and `.retries()` still applies to the
 release-listing requests and to the download's request-establishment phase (a mid-stream failure
@@ -421,6 +443,9 @@ on the system OpenSSL cert layout.
 // `rustdoc-args = ["--cfg", "docsrs"]` in Cargo.toml). Stable builds are unaffected because
 // the cfg is never set outside of the docs.rs environment.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Keep the crate's rustdoc intra-doc links honest: an unresolved `[link]` in any doc comment is a
+// hard error, not a silent warning. The full-crate check is the final barrier during a doc build.
+#![deny(rustdoc::broken_intra_doc_links)]
 
 // The HTTP transport is now an object-safe trait seam (`http_client::HttpClient`), so `reqwest` and
 // `ureq` are no longer mutually exclusive — both client impls can be compiled and one is selected at
@@ -522,7 +547,7 @@ pub mod version;
 /// is built, not at construction.
 pub use tls::Certificate;
 
-/// Re-export the crate's [`Error`](errors::Error) and [`Result`](errors::Result) at the crate root,
+/// Re-export the crate's [`Error`] and [`Result`] at the crate root,
 /// so consumers (and `ReleaseSource` implementors) can write `self_update::Result<T>` /
 /// `self_update::Error` without naming the `errors` module.
 pub use errors::{Error, Result};
@@ -614,9 +639,9 @@ fn confirm(msg: &str) -> Result<()> {
 ///
 /// Wrapped `String`s are version tags.
 ///
-/// This is the lightweight counterpart of [`ReleaseStatus`](update::ReleaseStatus), the richer
+/// This is the lightweight counterpart of [`ReleaseStatus`], the richer
 /// result of [`update_extended`](update::ReleaseUpdate::update_extended) which carries the full
-/// [`Release`](update::Release) (name, date, body, assets). Reach for `VersionStatus` when the
+/// [`Release`] (name, date, body, assets). Reach for `VersionStatus` when the
 /// version string is all you need; reach for `ReleaseStatus` when you need the installed release's
 /// details.
 #[derive(Debug, Clone)]
@@ -659,7 +684,7 @@ impl std::fmt::Display for VersionStatus {
 /// The archive format of a release asset, as detected from its file extension.
 ///
 /// `#[non_exhaustive]`, and the `Tar`/`Zip` variants are gated on the `archive-tar` / `archive-zip`
-/// features: if the matching feature is off the variant does not exist and [`detect_archive`] for
+/// features: if the matching feature is off the variant does not exist and `detect_archive` for
 /// that extension returns [`Error::ArchiveNotEnabled`] instead.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
@@ -922,10 +947,16 @@ impl Extract {
                     io::copy(&mut file, &mut output)?;
                     // Preserve the archived unix permission mode (notably the executable bit) so a
                     // binary extracted from a zip is runnable when installed to a custom path.
+                    // Mask off the setuid/setgid/sticky bits (`0o7000`): a crafted archive must not
+                    // be able to install a setuid binary, so only the standard `rwx` permission
+                    // bits (`0o777`) are honored.
                     #[cfg(unix)]
                     if let Some(mode) = file.unix_mode() {
                         use std::os::unix::fs::PermissionsExt;
-                        fs::set_permissions(&output_path, fs::Permissions::from_mode(mode))?;
+                        fs::set_permissions(
+                            &output_path,
+                            fs::Permissions::from_mode(mode & 0o777),
+                        )?;
                     }
                 }
             }
@@ -1046,11 +1077,13 @@ impl Extract {
 
                 let mut output = fs::File::create(&output_path)?;
                 io::copy(&mut file, &mut output)?;
-                // Preserve the archived unix permission mode so the extracted binary is runnable.
+                // Preserve the archived unix permission mode so the extracted binary is runnable,
+                // but mask off the setuid/setgid/sticky bits (`0o7000`) so a crafted archive cannot
+                // install a setuid binary; only the standard `rwx` bits (`0o777`) are honored.
                 #[cfg(unix)]
                 if let Some(mode) = file.unix_mode() {
                     use std::os::unix::fs::PermissionsExt;
-                    fs::set_permissions(&output_path, fs::Permissions::from_mode(mode))?;
+                    fs::set_permissions(&output_path, fs::Permissions::from_mode(mode & 0o777))?;
                 }
             }
         };
@@ -1369,6 +1402,10 @@ pub struct Download {
     progress_chars: String,
     timeout: Option<std::time::Duration>,
     on_progress: Option<ProgressCallback>,
+    /// Optional cap on the number of bytes streamed into `dest`. `None` (the default) means no cap,
+    /// preserving prior unbounded behavior. When set, the streaming download aborts with an error as
+    /// soon as the total bytes written would exceed this many bytes.
+    max_download_size: Option<u64>,
     /// Number of times to retry establishing the download request (before any bytes are streamed)
     /// with exponential backoff. `0` (the default) means a single attempt, preserving the prior
     /// no-retry behavior. A failure that occurs *after* streaming has begun is not retried (it would
@@ -1404,6 +1441,7 @@ impl std::fmt::Debug for Download {
                 "on_progress",
                 &self.on_progress.as_ref().map(|_| "<callback>"),
             )
+            .field("max_download_size", &self.max_download_size)
             .field("client", &self.client.as_ref().map(|_| "<http_client>"));
         #[cfg(feature = "async")]
         s.field(
@@ -1416,6 +1454,15 @@ impl std::fmt::Debug for Download {
         );
         s.finish()
     }
+}
+
+/// Build the error returned when a streaming download exceeds its configured
+/// [`max_download_size`](Download::max_download_size) cap. Reported as an [`Error::Io`] with a
+/// message naming the cap so the failure mode is unambiguous.
+fn max_download_size_exceeded(cap: u64) -> Error {
+    Error::Io(io::Error::other(format!(
+        "download exceeded the configured max_download_size cap of {cap} bytes"
+    )))
 }
 
 impl Download {
@@ -1431,6 +1478,7 @@ impl Download {
             progress_chars: DEFAULT_PROGRESS_CHARS.to_string(),
             timeout: None,
             on_progress: None,
+            max_download_size: None,
             retries: 0,
             retry_base_delay: std::time::Duration::from_millis(100),
             retry_max_delay: std::time::Duration::from_millis(3200),
@@ -1452,6 +1500,15 @@ impl Download {
     /// Set a timeout for the download request. Defaults to no timeout.
     pub fn timeout(&mut self, timeout: std::time::Duration) -> &mut Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Cap the number of bytes this download will stream into `dest`. Once the running total of
+    /// written bytes exceeds `max_bytes`, the download aborts with an [`Error`] instead of writing
+    /// an unbounded amount (useful to defend against a server that streams far more than the
+    /// advertised `Content-Length`). Defaults to no cap, so existing behavior is unchanged.
+    pub fn max_download_size(&mut self, max_bytes: u64) -> &mut Self {
+        self.max_download_size = Some(max_bytes);
         self
     }
 
@@ -1527,16 +1584,14 @@ impl Download {
     }
 
     /// Add a custom TLS root CA certificate the crate-built HTTP client will trust. Call multiple
-    /// times to add more than one. Ignored when an HTTP client is injected via
-    /// [`set_http_client`](Self::set_http_client) (the injected client owns its own TLS config). A
-    /// malformed certificate surfaces as an
-    /// [`Error::InvalidCertificate`](errors::Error::InvalidCertificate) from
-    /// [`download_to`](Self::download_to).
+    /// times to add more than one. Ignored when an HTTP client is injected via `set_http_client`
+    /// (the injected client owns its own TLS config). A malformed certificate surfaces as an
+    /// [`Error::InvalidCertificate`] from [`download_to`](Self::download_to).
     ///
     /// **ureq-only builds**: when the `reqwest` feature is disabled, the crate-built ureq client
     /// trusts *only* the supplied certificates (replacing the default Mozilla root set). Supply all
     /// CA certificates you need, including any public roots, or inject a `ureq::Agent` via
-    /// [`set_http_client`](Self::set_http_client) with a merged root set instead.
+    /// `set_http_client` with a merged root set instead.
     pub fn add_root_certificate(&mut self, cert: Certificate) -> &mut Self {
         self.root_certificates.push(cert);
         self
@@ -1558,7 +1613,7 @@ impl Download {
     /// `.request_header(self_update::http::header::ACCEPT, "application/octet-stream")`. The setter
     /// is infallible; a name or value that is not a valid HTTP header is deferred and surfaced from
     /// [`download_to`](Self::download_to) as an
-    /// [`Error::InvalidHeader`](errors::Error::InvalidHeader), matching the builders'
+    /// [`Error::InvalidHeader`], matching the builders'
     /// `request_header` verb.
     pub fn request_header<N, V>(&mut self, name: N, value: V) -> &mut Self
     where
@@ -1639,7 +1694,7 @@ impl Download {
             |e, backoff| {
                 log::warn!(
                     "self_update: download request to {} failed ({e}); retrying in {backoff}ms",
-                    self.url
+                    crate::errors::redact_url(&self.url)
                 );
                 std::thread::sleep(std::time::Duration::from_millis(backoff));
             },
@@ -1685,6 +1740,11 @@ impl Download {
             }
             src.consume(n);
             downloaded += n as u64;
+            if let Some(cap) = self.max_download_size
+                && downloaded > cap
+            {
+                return Err(max_download_size_exceeded(cap));
+            }
 
             #[cfg(feature = "progress-bar")]
             if let Some(ref mut bar) = bar {
@@ -1744,7 +1804,7 @@ impl Download {
             |e, backoff| {
                 log::warn!(
                     "self_update: download request to {} failed ({e}); retrying in {backoff}ms",
-                    self.url
+                    crate::errors::redact_url(&self.url)
                 );
             },
             |backoff| tokio::time::sleep(std::time::Duration::from_millis(backoff)),
@@ -1785,6 +1845,11 @@ impl Download {
             let chunk = chunk?;
             dest.write_all(&chunk)?;
             downloaded += chunk.len() as u64;
+            if let Some(cap) = self.max_download_size
+                && downloaded > cap
+            {
+                return Err(max_download_size_exceeded(cap));
+            }
 
             #[cfg(feature = "progress-bar")]
             if let Some(ref mut bar) = bar {
@@ -2397,6 +2462,200 @@ mod tests {
             "with no Content-Length the callback's total must be None, got {:?}",
             totals
         );
+    }
+
+    // --- S1: presigned-URL redaction in the download retry warning ---------------------------
+
+    /// A `log::Log` that captures every record's formatted message into a shared global buffer.
+    /// Tests filter the buffer by a unique URL host so a single global logger can serve them all.
+    struct CaptureLogger;
+    static CAPTURE_LOGGER: CaptureLogger = CaptureLogger;
+
+    fn log_capture() -> &'static std::sync::Mutex<Vec<String>> {
+        static BUF: std::sync::OnceLock<std::sync::Mutex<Vec<String>>> = std::sync::OnceLock::new();
+        BUF.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+    }
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _: &log::Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record) {
+            log_capture()
+                .lock()
+                .unwrap()
+                .push(format!("{}", record.args()));
+        }
+        fn flush(&self) {}
+    }
+
+    fn install_capture_logger() {
+        static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        INIT.get_or_init(|| {
+            // Ignore an error if another harness already set the global logger.
+            let _ = log::set_logger(&CAPTURE_LOGGER);
+            log::set_max_level(log::LevelFilter::Warn);
+        });
+    }
+
+    #[test]
+    fn download_retry_warning_redacts_presigned_signature() {
+        // S1: a download that retries must not leak a presigned S3 `X-Amz-Signature` /
+        // `X-Amz-Credential` into the retry warning. Drive `download_to` with a flaky client (one
+        // failure, then success) so the retry closure fires exactly one `log::warn!`, and assert the
+        // captured line carries neither secret. On the pre-fix code (which logged the raw
+        // `self.url`) the signature would appear verbatim and this test fails.
+        use std::sync::atomic::AtomicU32;
+
+        install_capture_logger();
+        let sig = "abc123-secret-signature-value";
+        let cred = "AKIAREDACTTESTONLY";
+        let host = "s3-redact-retry-test.invalid";
+        let url = format!(
+            "https://{host}/app.tar.gz?X-Amz-Credential={cred}%2F20260101\
+             &X-Amz-Expires=300&X-Amz-Signature={sig}&X-Amz-SignedHeaders=host"
+        );
+
+        let attempts = std::sync::Arc::new(AtomicU32::new(0));
+        let client = std::sync::Arc::new(FlakyDlClient {
+            body: b"ok".to_vec(),
+            fail_times: AtomicU32::new(1),
+            attempts: attempts.clone(),
+        });
+
+        let mut out = Vec::new();
+        let mut dl = Download::from_url(url);
+        dl.set_http_client(
+            Some(client),
+            #[cfg(feature = "async")]
+            None,
+        );
+        dl.set_retries(
+            1,
+            std::time::Duration::from_millis(1),
+            std::time::Duration::from_millis(2),
+        );
+        dl.download_to(&mut out).unwrap();
+
+        let lines: Vec<String> = log_capture()
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|l| l.contains(host))
+            .cloned()
+            .collect();
+        assert!(
+            !lines.is_empty(),
+            "the retry closure should have logged a warning for {host}"
+        );
+        for line in &lines {
+            assert!(
+                !line.contains(sig),
+                "presigned signature leaked into the retry warning: {line}"
+            );
+            assert!(
+                !line.contains(cred),
+                "presigned credential leaked into the retry warning: {line}"
+            );
+        }
+    }
+
+    // --- S3: extracted zip modes must not carry setuid/setgid/sticky --------------------------
+
+    #[cfg(all(unix, feature = "archive-zip"))]
+    #[test]
+    fn extract_zip_masks_setuid_setgid_sticky_bits() {
+        // S3: a zip entry archived with a setuid mode (0o4755) must NOT install a setuid file; the
+        // extractor masks the mode to `& 0o777`, so the setuid/setgid/sticky bits are dropped while
+        // the ordinary rwx bits survive. On the pre-fix code (`from_mode(mode)`) the installed file
+        // would be setuid and this test fails.
+        use std::io::Write as _;
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let zip_path = tmp.path().join("archive.zip");
+        {
+            let file = fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored)
+                .unix_permissions(0o4755);
+            zip.start_file("payload", opts).unwrap();
+            zip.write_all(b"#!/bin/sh\n").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let out_dir = tmp.path().join("out");
+        fs::create_dir_all(&out_dir).unwrap();
+        let mut ex = Extract::from_source(&zip_path);
+        ex.archive(ArchiveKind::Zip);
+        ex.extract_into(&out_dir).unwrap();
+
+        let extracted = out_dir.join("payload");
+        let mode = fs::metadata(&extracted).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o7000,
+            0,
+            "extracted file must carry no setuid/setgid/sticky bits, got mode {mode:o}"
+        );
+        assert_eq!(
+            mode & 0o777,
+            0o755,
+            "the ordinary rwx bits should be preserved, got mode {mode:o}"
+        );
+    }
+
+    // --- S4: optional max_download_size cap ---------------------------------------------------
+
+    #[test]
+    fn download_max_download_size_aborts_when_body_exceeds_cap() {
+        // S4: a body larger than the configured cap aborts the streaming download with an error
+        // naming the cap, instead of writing an unbounded amount to `dest`.
+        let body = vec![0u8; 4096];
+        let client = std::sync::Arc::new(DlClient {
+            body: body.clone(),
+            content_length: Some(body.len() as u64),
+            requested: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        });
+
+        let mut out = Vec::new();
+        let mut dl = Download::from_url("https://nonroutable.invalid/big.bin");
+        dl.set_http_client(
+            Some(client),
+            #[cfg(feature = "async")]
+            None,
+        );
+        dl.max_download_size(1024);
+        let res = dl.download_to(&mut out);
+        assert!(res.is_err(), "a body over the cap must error");
+        let msg = res.unwrap_err().to_string();
+        assert!(
+            msg.contains("max_download_size"),
+            "the error should name the cap: {msg}"
+        );
+    }
+
+    #[test]
+    fn download_max_download_size_allows_body_under_cap() {
+        // S4: with the default (no cap) unchanged, an explicit cap larger than the body still lets
+        // the whole body download successfully.
+        let body = vec![7u8; 512];
+        let client = std::sync::Arc::new(DlClient {
+            body: body.clone(),
+            content_length: Some(body.len() as u64),
+            requested: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        });
+
+        let mut out = Vec::new();
+        let mut dl = Download::from_url("https://nonroutable.invalid/small.bin");
+        dl.set_http_client(
+            Some(client),
+            #[cfg(feature = "async")]
+            None,
+        );
+        dl.max_download_size(1024);
+        dl.download_to(&mut out).unwrap();
+        assert_eq!(out, body, "a body under the cap downloads in full");
     }
 
     /// Async test-double response: yields the body as a single `bytes_stream` chunk and as `text`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 /*!
 
-[![Build status](https://ci.appveyor.com/api/projects/status/xlkq8rd73cla4ixw/branch/master?svg=true)](https://ci.appveyor.com/project/jaemk/self-update/branch/master)
 [![crates.io:clin](https://img.shields.io/crates/v/self_update.svg?label=self_update)](https://crates.io/crates/self_update)
 [![docs](https://docs.rs/self_update/badge.svg)](https://docs.rs/self_update)
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,7 +27,7 @@ macro_rules! request_config_setters {
         /// strings work: `.request_header("X-Foo", "bar")` or
         /// `.request_header(self_update::http::header::ACCEPT, "application/json")`. A name or value
         /// that is not a valid HTTP header is reported as an `Error::InvalidHeader` from
-        /// [`build()`](Self::build) rather than panicking here.
+        /// `build()` rather than panicking here.
         pub fn request_header<N, V>(&mut self, name: N, value: V) -> &mut Self
         where
             N: ::core::convert::TryInto<crate::http_client::header::HeaderName>,
@@ -137,7 +137,7 @@ macro_rules! request_config_setters {
         /// download). Call multiple times to add more than one. Use this to reach a server behind a
         /// private/internal CA without injecting a whole pre-built client. A malformed certificate
         /// surfaces as an [`Error::InvalidCertificate`](crate::errors::Error::InvalidCertificate)
-        /// from [`build()`](Self::build). Construct the argument with
+        /// from `build()`. Construct the argument with
         /// [`Certificate::from_pem`](crate::Certificate::from_pem) or
         /// [`Certificate::from_der`](crate::Certificate::from_der).
         ///
@@ -257,7 +257,7 @@ macro_rules! impl_update_config_accessors {
                 self.common.checksum.as_ref()
             }
             #[cfg(feature = "signatures")]
-            fn verify_keys(&self) -> &[crate::VerifyingKey] {
+            fn verifying_keys(&self) -> &[crate::VerifyingKey] {
                 &self.common.verifying_keys
             }
         }
@@ -358,6 +358,69 @@ macro_rules! impl_sync_update_verbs {
             /// newest strictly-newer [`Release`](crate::Release), or `None` when already up to date.
             pub fn is_update_available(&self) -> crate::Result<Option<crate::Release>> {
                 Ok(self.get_newer_releases()?.into_vec().into_iter().next())
+            }
+        }
+    };
+}
+
+/// Emit the inherent async update verbs on a backend `AsyncUpdate(Update)` newtype.
+///
+/// `build_async()` returns the distinct `AsyncUpdate` newtype (not the blocking `Update`), so these
+/// inherent `async` methods let callers write `.build_async()?.update_async().await` without
+/// importing the sealed [`AsyncReleaseUpdate`](crate::AsyncReleaseUpdate) trait. Because the newtype
+/// exposes *only* the async verbs, a stray blocking `.update()` on an async-built updater is a
+/// compile error rather than a silent block of the executor. Each method forwards to the
+/// [`AsyncReleaseUpdate`] impl on the inner blocking `Update` at `self.0`.
+#[cfg(feature = "async")]
+macro_rules! impl_async_update_verbs {
+    ($t:ty) => {
+        impl $t {
+            /// Display release information and update the current binary to the latest release,
+            /// pending confirmation. Returns a [`VersionStatus`](crate::VersionStatus). See
+            /// [`AsyncReleaseUpdate::update_async`](crate::AsyncReleaseUpdate::update_async).
+            pub async fn update_async(&self) -> crate::Result<crate::VersionStatus> {
+                crate::AsyncReleaseUpdate::update_async(&self.0).await
+            }
+
+            /// Same as [`update_async`](Self::update_async) but returns a
+            /// [`ReleaseStatus`](crate::ReleaseStatus) with the full release details.
+            pub async fn update_extended_async(&self) -> crate::Result<crate::ReleaseStatus> {
+                crate::AsyncReleaseUpdate::update_extended_async(&self.0).await
+            }
+
+            /// Fetch the single newest release (raw, unfiltered). See
+            /// [`AsyncReleaseUpdate::get_latest_release_async`](crate::AsyncReleaseUpdate::get_latest_release_async).
+            pub async fn get_latest_release_async(&self) -> crate::Result<crate::Releases> {
+                crate::AsyncReleaseUpdate::get_latest_release_async(&self.0).await
+            }
+
+            /// Fetch the releases newer than the current version. See
+            /// [`AsyncReleaseUpdate::get_newer_releases_async`](crate::AsyncReleaseUpdate::get_newer_releases_async).
+            pub async fn get_newer_releases_async(&self) -> crate::Result<crate::Releases> {
+                crate::AsyncReleaseUpdate::get_newer_releases_async(&self.0).await
+            }
+
+            /// Fetch details of the release matching `ver`. See
+            /// [`AsyncReleaseUpdate::get_release_version_async`](crate::AsyncReleaseUpdate::get_release_version_async).
+            pub async fn get_release_version_async(
+                &self,
+                ver: &str,
+            ) -> crate::Result<crate::Release> {
+                crate::AsyncReleaseUpdate::get_release_version_async(&self.0, ver).await
+            }
+
+            /// Whether a release newer than the current version is available, returning it if so.
+            ///
+            /// A convenience over [`get_newer_releases_async`](Self::get_newer_releases_async):
+            /// returns the newest strictly-newer [`Release`](crate::Release), or `None` when already
+            /// up to date.
+            pub async fn is_update_available_async(&self) -> crate::Result<Option<crate::Release>> {
+                Ok(self
+                    .get_newer_releases_async()
+                    .await?
+                    .into_vec()
+                    .into_iter()
+                    .next())
             }
         }
     };
@@ -581,9 +644,9 @@ macro_rules! impl_common_builder_setters {
         ///
         /// This runs **last** in the verification chain and on the **extracted binary**, not the
         /// downloaded archive. The full order is: [`verify_checksum`](Self::verify_checksum) (digest
-        /// of the archive) -> signature ([`verify_keys`](Self::verify_keys), over the archive) ->
+        /// of the archive) -> signature ([`verifying_keys`](Self::verifying_keys), over the archive) ->
         /// extract -> `verify_binary` (the extracted binary) -> replace. Use
-        /// `verify_checksum`/`verify_keys` to gate the download by content; use `verify_binary` to
+        /// `verify_checksum`/`verifying_keys` to gate the download by content; use `verify_binary` to
         /// gate it by running the new binary. A returned error's message becomes the reason of the
         /// resulting `Error::VerificationRejected`.
         pub fn verify_binary(

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::borrow::Cow;
 use std::fs;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use crate::http_client::{self, header};
 use crate::{Download, Extract, Move, VersionStatus, confirm, errors::*, version};
@@ -45,7 +45,7 @@ impl ReleaseAsset {
 /// The richer result of [`update_extended`](ReleaseUpdate::update_extended) (and its async sibling
 /// `update_extended_async`): it carries the full [`Release`] that was installed.
 ///
-/// This is the extended counterpart of [`VersionStatus`](crate::VersionStatus), the lightweight
+/// This is the extended counterpart of [`VersionStatus`], the lightweight
 /// result of [`update`](ReleaseUpdate::update) which carries only the version tag. Reach for
 /// `ReleaseStatus` when you need the installed release's details (name, date, body, assets); reach
 /// for `VersionStatus` when the version string is all you need. Convert with
@@ -60,7 +60,7 @@ pub enum ReleaseStatus {
 }
 
 impl ReleaseStatus {
-    /// Turn the extended information into the crate's standard [`VersionStatus`](crate::VersionStatus) enum
+    /// Turn the extended information into the crate's standard [`VersionStatus`] enum
     pub fn into_version_status(self, current_version: String) -> VersionStatus {
         match self {
             ReleaseStatus::UpToDate => VersionStatus::UpToDate(current_version),
@@ -374,12 +374,20 @@ impl Releases {
     ///
     /// This consults only the already-fetched releases — no further request is made, so the only
     /// `Err` this can return is a version-parse failure ([`Error::SemVer`]) or, when no current
-    /// version is known (a bare listing), [`Error::MissingField`]; it never surfaces a transport or
-    /// HTTP error.
+    /// version is known (a bare listing), [`Error::NoCurrentVersion`]; it never surfaces a transport
+    /// or HTTP error.
+    ///
+    /// # See also
+    ///
+    /// The per-backend `Update::is_update_available` is the configured-updater counterpart: it
+    /// *fetches* the latest release and returns `Result<Option<Release>>` (the newer [`Release`], or
+    /// `None` when up to date), whereas this method returns `Result<bool>` over the releases already
+    /// in hand and never makes a request.
     pub fn is_update_available(&self) -> Result<bool> {
-        let current_version = self.current_version.as_deref().ok_or(Error::MissingField {
-            field: "current_version",
-        })?;
+        let current_version = self
+            .current_version
+            .as_deref()
+            .ok_or(Error::NoCurrentVersion)?;
         for r in &self.releases {
             if version::bump_is_greater(current_version, r.version())? {
                 return Ok(true);
@@ -433,7 +441,7 @@ impl<'a> IntoIterator for &'a Releases {
 /// sync `ReleaseSource` from the async API, wrap it in
 /// [`backends::custom::Blocking`](crate::backends::custom::Blocking).
 ///
-/// On failure, return one of the public [`Error`](crate::errors::Error) variants. For a completed
+/// On failure, return one of the public [`Error`] variants. For a completed
 /// request with a non-2xx status use the structured variants — e.g.
 /// `Error::HttpStatus { status: 503, url: "…".into() }` for a transient server error, or
 /// `Error::NotFound { url: "…".into() }` for a missing resource — and `Error::Transport(…)` for a
@@ -482,7 +490,7 @@ pub trait ReleaseSource: Send + Sync {
 /// [`backends::custom::Blocking`](crate::backends::custom::Blocking), which runs the sync fetches
 /// on [`tokio::task::spawn_blocking`].
 ///
-/// On failure, return one of the public [`Error`](crate::errors::Error) variants. For a completed
+/// On failure, return one of the public [`Error`] variants. For a completed
 /// request with a non-2xx status use the structured variants — e.g.
 /// `Error::HttpStatus { status: 503, url: "…".into() }` for a transient server error, or
 /// `Error::NotFound { url: "…".into() }` for a missing resource — and `Error::Transport(…)` for a
@@ -526,9 +534,10 @@ pub trait AsyncReleaseSource: Send + Sync {
 /// object-safe — that is expected and matches [`AsyncReleaseSource`]: it is nameable and usable as
 /// a generic bound, but never as a `dyn AsyncReleaseUpdate`.
 ///
-/// The shared accessor methods live on the [`UpdateConfig`] supertrait; bring it into scope
-/// (`use self_update::UpdateConfig;`) only to call them from generic code bounded
-/// `U: AsyncReleaseUpdate`.
+/// The shared accessor methods live on the [`UpdateConfig`] supertrait. In generic code bounded
+/// `U: AsyncReleaseUpdate` they are already in scope via the supertrait bound (no import needed);
+/// bring the trait into scope (`use self_update::UpdateConfig;`) only to call them on a concrete
+/// backend `Update` value.
 // `UpdateInternals` is intentionally `pub(crate)`: it carries the crate-private-typed accessors
 // and seals the trait further. The public trait is reachable but the bound is not nameable
 // downstream, which is the intent.
@@ -602,9 +611,10 @@ pub(crate) mod sealed {
 /// not implement the sync fetch methods.
 ///
 /// You rarely name this trait directly: accessor calls (e.g. `bin_name()`, `current_version()`,
-/// `target()`) resolve on a `dyn ReleaseUpdate` value without importing it. It is only needed in
-/// scope (`use self_update::UpdateConfig;`) to call an accessor from generic code bounded
-/// `R: ReleaseUpdate`.
+/// `target()`) resolve on a `dyn ReleaseUpdate` value without importing it, and in generic code
+/// bounded `R: ReleaseUpdate` they are in scope via the supertrait bound (also no import). It is
+/// only needed in scope (`use self_update::UpdateConfig;`) to call an accessor on a concrete
+/// backend `Update` value.
 pub trait UpdateConfig: sealed::Sealed {
     /// Current version of binary being updated
     fn current_version(&self) -> &str;
@@ -653,7 +663,7 @@ pub trait UpdateConfig: sealed::Sealed {
     /// Construct a header with an authorisation entry if an auth token is provided.
     ///
     /// The trait default is a no-op (empty header map): the authorization scheme now lives in the
-    /// per-backend [`RequestConfig`](crate::backends::common::RequestConfig) and is applied by the
+    /// per-backend `RequestConfig` and is applied by the
     /// shared header-derivation, not here. Backends that need a custom user-agent / scheme still
     /// override this (github/gitlab/gitea).
     fn api_headers(&self, _auth_token: Option<&str>) -> Result<http_client::HeaderMap> {
@@ -707,7 +717,7 @@ pub(crate) trait UpdateInternals: sealed::Sealed {
 
     /// ed25519ph verifying keys to validate a download's authenticity
     #[cfg(feature = "signatures")]
-    fn verify_keys(&self) -> &[crate::VerifyingKey] {
+    fn verifying_keys(&self) -> &[crate::VerifyingKey] {
         &[]
     }
 }
@@ -720,11 +730,12 @@ pub(crate) trait UpdateInternals: sealed::Sealed {
 /// `update()` / `update_extended()` on it — but you do not implement it yourself.
 ///
 /// The shared accessor methods live on the [`UpdateConfig`] supertrait. They resolve on a
-/// `dyn ReleaseUpdate` without importing it; bring it into scope (`use self_update::UpdateConfig;`)
-/// only to call them from generic code bounded `R: ReleaseUpdate`.
+/// `dyn ReleaseUpdate` without importing it, and in generic code bounded `R: ReleaseUpdate` they
+/// are in scope via the supertrait bound (also no import); bring it into scope
+/// (`use self_update::UpdateConfig;`) only to call them on a concrete backend `Update` value.
 ///
 /// The trait is sealed transitively: its [`UpdateConfig`] supertrait requires
-/// [`sealed::Sealed`](sealed) (implemented only inside this crate), so `ReleaseUpdate` cannot be
+/// `sealed::Sealed` (implemented only inside this crate), so `ReleaseUpdate` cannot be
 /// implemented for a foreign type even though the trait itself has no visible seal.
 #[allow(private_bounds)]
 pub trait ReleaseUpdate: UpdateConfig + UpdateInternals {
@@ -867,11 +878,16 @@ fn choose_latest_release(
             release.version()
         ),
     );
-    let qualifier = if version::bump_is_compatible(current_version, release.version())? {
-        ""
-    } else {
-        "*NOT* "
-    };
+    // Both versions were already validated as semver upstream (the selection filters above parse
+    // them), so this comparison cannot actually error. Express that invariant with `unwrap_or(false)`
+    // — consistent with the `bump_is_greater`/`bump_is_compatible` filter sites above — rather than a
+    // `?` that would imply a live error path here.
+    let qualifier =
+        if version::bump_is_compatible(current_version, release.version()).unwrap_or(false) {
+            ""
+        } else {
+            "*NOT* "
+        };
     println(
         show_output,
         &format!("New release is {}compatible", qualifier),
@@ -994,7 +1010,19 @@ fn build_download<U: UpdateConfig + UpdateInternals + ?Sized>(
         .apply_auth(target_asset.download_url(), &mut headers)?;
     // Apply the user's extra request headers to the download too. This runs after the ACCEPT and
     // auth headers set above, so a user-supplied header of the same name overrides them here.
+    //
+    // S2: a user-supplied `Authorization` (set via `request_header(AUTHORIZATION, ..)`) is a
+    // credential, so it is host-gated exactly like the crate's derived token — forwarded only to a
+    // host `auth_allowed_for` permits (the configured API host or an `allow_auth_host` entry, over
+    // https / loopback). A server-chosen next-page or download host that is not authorized does not
+    // receive it, so a malicious release server cannot harvest the user's Authorization.
+    let user_auth_allowed = u
+        .request_config()
+        .auth_allowed_for(target_asset.download_url());
     for (name, value) in u.request_headers() {
+        if name == header::AUTHORIZATION && !user_auth_allowed {
+            continue;
+        }
         headers.insert(name.clone(), value.clone());
     }
     download.replace_headers(headers);
@@ -1065,7 +1093,7 @@ impl FinishCtx {
             #[cfg(feature = "checksums")]
             verify_checksum: u.verify_checksum().cloned(),
             #[cfg(feature = "signatures")]
-            verify_keys: u.verify_keys().to_vec(),
+            verify_keys: u.verifying_keys().to_vec(),
         }
     }
 }
@@ -1107,20 +1135,38 @@ fn finish_update_owned(
 
     let bin_path_str = Cow::Borrowed(ctx.bin_path_in_archive.as_str());
 
-    // Substitute the `var` variable in a string with the given `val` value.
-    // Variable format: `{{ var }}`
-    fn substitute<'a: 'b, 'b>(str: &'a str, var: &str, val: &str) -> Cow<'b, str> {
-        let format = format!(r"\{{\{{[[:space:]]*{}[[:space:]]*\}}\}}", var);
+    // The `{{ version }}` / `{{ target }}` / `{{ bin }}` template matchers. Hoisted to `static`
+    // `LazyLock<Regex>` (I6) so each is compiled once, not rebuilt from its constant pattern on
+    // every call. Pattern is unchanged: `{{`, optional whitespace, the variable name, optional
+    // whitespace, `}}`.
+    static VERSION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\{\{[[:space:]]*version[[:space:]]*\}\}").unwrap());
+    static TARGET_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\{\{[[:space:]]*target[[:space:]]*\}\}").unwrap());
+    static BIN_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\{\{[[:space:]]*bin[[:space:]]*\}\}").unwrap());
+
+    // Substitute a `{{ var }}` placeholder (matched by `re`) in `str` with `val`.
+    //
+    // S6 (defense-in-depth): the `{{ version }}` value comes from the release server, so a
+    // malicious version like `../evil` (or one with a `/`/`\` separator) could redirect the
+    // extraction path outside the temp dir. When the template actually references the variable,
+    // reject a value that is not a single safe path component (reusing `is_safe_asset_name`, which
+    // rejects `/`, `\`, `:`, `.`, `..`, roots, and drive prefixes) before it can reach the path.
+    fn substitute<'a: 'b, 'b>(re: &Regex, str: &'a str, val: &str) -> Result<Cow<'b, str>> {
+        if re.is_match(str) && !is_safe_asset_name(val) {
+            return Err(Error::InvalidAssetName {
+                name: val.to_string(),
+            });
+        }
         // `NoExpand` so a `$` in `val` (e.g. a bin name or version containing `$`) is inserted
         // literally, not interpreted as a regex capture-group reference.
-        Regex::new(&format)
-            .unwrap()
-            .replace_all(str, regex::NoExpand(val))
+        Ok(re.replace_all(str, regex::NoExpand(val)))
     }
 
-    let bin_path_str = substitute(&bin_path_str, "version", ctx.release.version());
-    let bin_path_str = substitute(&bin_path_str, "target", &ctx.target);
-    let bin_path_str = substitute(&bin_path_str, "bin", &ctx.bin_name);
+    let bin_path_str = substitute(&VERSION_RE, &bin_path_str, ctx.release.version())?;
+    let bin_path_str = substitute(&TARGET_RE, &bin_path_str, &ctx.target)?;
+    let bin_path_str = substitute(&BIN_RE, &bin_path_str, &ctx.bin_name)?;
     let bin_path_str = bin_path_str.as_ref();
 
     Extract::from_source(tmp_archive_path).extract_file(tmp_archive_dir.path(), bin_path_str)?;
@@ -1677,11 +1723,10 @@ mod tests {
         assert!(
             matches!(
                 listing.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
-            "a bare listing must error on is_update_available"
+            "a bare listing must error on is_update_available with the distinct NoCurrentVersion \
+             variant, not the misleading MissingField builder-field error"
         );
     }
 
@@ -1715,11 +1760,15 @@ mod tests {
         assert!(
             matches!(
                 listing.is_update_available(),
-                Err(crate::errors::Error::MissingField {
-                    field: "current_version"
-                })
+                Err(crate::errors::Error::NoCurrentVersion)
             ),
             "a listing with no current version must error on is_update_available()"
+        );
+        // The message must be self-describing, not the builder-field `MissingField` message.
+        let msg = listing.is_update_available().unwrap_err().to_string();
+        assert!(
+            msg.contains("no current_version to compare against"),
+            "the error must self-describe the bare-listing case, got: {msg}"
         );
     }
 
@@ -2312,15 +2361,19 @@ mod tests {
     #[test]
     fn download_path_honors_user_authorization_override() {
         // A backend token is configured AND the user supplies their own Authorization via
-        // `request_header`. The override must win on the DOWNLOAD path, exactly like the listing path.
+        // `request_header`. The override must win over the backend token on the DOWNLOAD path,
+        // exactly like the listing path — when the asset host is authorized (here via
+        // `allow_auth_host`, since the loopback stub is not the github API host).
         use crate::http_client::header::AUTHORIZATION;
         let (base, captured) = download_auth_capture_stub();
+        let host = crate::backends::common::host_of(&base).unwrap();
         let upd = crate::backends::github::Update::configure()
             .repo_owner("o")
             .repo_name("r")
             .bin_name("app")
             .current_version("0.1.0")
             .auth_token("secret")
+            .allow_auth_host(host)
             .request_header(AUTHORIZATION, "Bearer user-override")
             .build()
             .unwrap();
@@ -2332,7 +2385,37 @@ mod tests {
         assert_eq!(
             captured_download_authorization(&lines),
             Some("Bearer user-override".to_string()),
-            "a user AUTHORIZATION override must win over the backend token on the download path"
+            "a user AUTHORIZATION override must win over the backend token, and be forwarded to the \
+             authorized asset host"
+        );
+    }
+
+    #[cfg(feature = "github")]
+    #[test]
+    fn download_path_drops_user_authorization_for_disallowed_host() {
+        // S2: a user-supplied `Authorization` (via `request_header`) is a credential, so it must be
+        // host-gated exactly like the crate's derived token. The loopback stub is NOT the github API
+        // host and is NOT in `allow_auth_host`, so the user's Authorization must be dropped, not
+        // leaked to the server-chosen download host.
+        use crate::http_client::header::AUTHORIZATION;
+        let (base, captured) = download_auth_capture_stub();
+        let upd = crate::backends::github::Update::configure()
+            .repo_owner("o")
+            .repo_name("r")
+            .bin_name("app")
+            .current_version("0.1.0")
+            .request_header(AUTHORIZATION, "Bearer user-secret")
+            .build()
+            .unwrap();
+        let asset = super::ReleaseAsset::new("app.tar.gz", format!("{base}/app.tar.gz"));
+        let download = super::build_download(&upd, &asset).unwrap();
+        let mut out = Vec::new();
+        download.download_to(&mut out).unwrap();
+        let lines = captured.lock().unwrap().clone();
+        assert_eq!(
+            captured_download_authorization(&lines),
+            None,
+            "a user Authorization must NOT be forwarded to a disallowed (cross-origin) download host"
         );
     }
 
@@ -2917,6 +3000,138 @@ mod tests {
             "expected Signature error for wrong zip key, got: {err}"
         );
         Ok(())
+    }
+
+    // --- S6: template-substitution path-traversal guard --------------------------------------
+
+    /// Build a [`FinishCtx`] for the substitution guard tests. The archive is never read (the guard
+    /// fires before extraction), so `bin_path_in_archive` + the (attacker-controlled) `version`
+    /// drive the outcome.
+    fn traversal_ctx(bin_path_in_archive: &str, version: &str) -> super::FinishCtx {
+        super::FinishCtx {
+            release: rel(version),
+            bin_install_path: std::path::PathBuf::from("unused"),
+            target: "x86_64-unknown-linux-gnu".to_string(),
+            bin_name: "app".to_string(),
+            bin_path_in_archive: bin_path_in_archive.to_string(),
+            show_output: false,
+            verify_callback: None,
+            #[cfg(feature = "checksums")]
+            verify_checksum: None,
+            #[cfg(feature = "signatures")]
+            verify_keys: vec![],
+        }
+    }
+
+    // A malicious release `version` like `../evil` substituted into the extraction path must be
+    // rejected (S6), before any archive read, with `Error::InvalidAssetName` naming the offending
+    // component. Without the guard this would redirect extraction outside the temp dir.
+    #[test]
+    fn finish_update_rejects_traversal_in_substituted_version() {
+        let ctx = traversal_ctx("{{ version }}/app", "../evil");
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("archive.tar.gz");
+        let res = super::finish_update_owned(ctx, dir, &archive);
+        match res {
+            Err(super::Error::InvalidAssetName { name }) => {
+                assert_eq!(name, "../evil", "the offending component must be named");
+            }
+            other => panic!("expected InvalidAssetName for a traversal version, got {other:?}"),
+        }
+    }
+
+    // A separator injected through the substituted value (e.g. `sub/evil`) is likewise rejected.
+    #[test]
+    fn finish_update_rejects_separator_in_substituted_version() {
+        let ctx = traversal_ctx("{{ version }}", "sub/evil");
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("archive.tar.gz");
+        assert!(
+            matches!(
+                super::finish_update_owned(ctx, dir, &archive),
+                Err(super::Error::InvalidAssetName { .. })
+            ),
+            "a `/` in a substituted component must be rejected"
+        );
+    }
+
+    // The guard only fires for a variable the template actually references. A weird `version` that
+    // never reaches the path (template has no `{{ version }}`) must NOT fail here; extraction of a
+    // safe, literal path proceeds to the archive read (which then errors on the missing dummy file,
+    // an IO error — not `InvalidAssetName`).
+    #[test]
+    fn finish_update_does_not_reject_unreferenced_substitution_value() {
+        let ctx = traversal_ctx("plain-bin", "../evil");
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("archive.tar.gz");
+        let res = super::finish_update_owned(ctx, dir, &archive);
+        assert!(
+            !matches!(res, Err(super::Error::InvalidAssetName { .. })),
+            "an unreferenced traversal value must not trigger the substitution guard, got {res:?}"
+        );
+    }
+
+    // --- S2: credential host-gate parity (RequestConfig::auth_allowed_for) --------------------
+
+    // The host-gate mirrors `RequestConfig::auth_allowed_for`: a matching host over https is
+    // allowed; a non-matching host is not; and a matching host over plain http is not (unless
+    // loopback / insecure override).
+    #[test]
+    fn config_auth_allowed_for_gates_host_and_scheme() {
+        let cfg = crate::backends::common::RequestConfig {
+            auth_base_host: Some("api.example.com".into()),
+            auth_hosts: vec!["cdn.example.com".into()],
+            ..Default::default()
+        };
+
+        assert!(
+            cfg.auth_allowed_for("https://api.example.com/asset"),
+            "the configured API host over https is allowed"
+        );
+        assert!(
+            cfg.auth_allowed_for("https://cdn.example.com/asset"),
+            "an allow_auth_host entry over https is allowed"
+        );
+        assert!(
+            !cfg.auth_allowed_for("https://evil.example.net/asset"),
+            "an unlisted host must be rejected"
+        );
+        assert!(
+            !cfg.auth_allowed_for("http://api.example.com/asset"),
+            "a matching host over plain http (non-loopback) must be rejected"
+        );
+    }
+
+    // Loopback hosts are allowed over plain http (only when host-matched), matching the derived-token
+    // rule; the insecure-forwarding flag lifts the https requirement for any matched host.
+    #[test]
+    fn config_auth_allowed_for_loopback_and_insecure_flag() {
+        let cfg = crate::backends::common::RequestConfig {
+            auth_hosts: vec!["127.0.0.1".into()],
+            ..Default::default()
+        };
+        assert!(
+            cfg.auth_allowed_for("http://127.0.0.1:8080/asset"),
+            "a host-matched loopback address is allowed over http"
+        );
+
+        let mut cfg = crate::backends::common::RequestConfig {
+            auth_base_host: Some("internal.example.com".into()),
+            ..Default::default()
+        };
+        assert!(
+            !cfg.auth_allowed_for("http://internal.example.com/asset"),
+            "http to a matched non-loopback host is rejected by default"
+        );
+        cfg.allow_insecure_auth = true;
+        assert!(
+            cfg.auth_allowed_for("http://internal.example.com/asset"),
+            "allow_insecure_auth lifts the https requirement for a matched host"
+        );
+        assert!(
+            !cfg.auth_allowed_for("http://other.example.com/asset"),
+            "allow_insecure_auth still requires a host match"
+        );
     }
 
     // --- asset-name path-traversal guard (J1) ------------------------------------------------

--- a/src/version.rs
+++ b/src/version.rs
@@ -48,8 +48,7 @@ pub fn bump_is_compatible(current: &str, other: &str) -> Result<bool> {
     let other = Version::parse(other)?;
     Ok(if !current.pre.is_empty() {
         current.major == other.major
-            && ((other.minor >= current.minor)
-                || (current.minor == other.minor && other.patch >= current.patch))
+            && ((other.minor > current.minor) || (current.minor == other.minor && other > current))
     } else if other.major == 0 && current.major == 0 {
         current.minor == other.minor && other.patch > current.patch && other.pre.is_empty()
     } else if other.major > 0 {
@@ -114,6 +113,15 @@ mod test {
         assert!(bump_is_compatible("2.0.0-alpha.0", "2.0.0").unwrap());
         assert!(bump_is_compatible("2.0.0-alpha.0", "2.0.1").unwrap());
         assert!(bump_is_compatible("2.0.0-alpha.0", "2.1.0").unwrap());
+
+        // Pre-release-to-older-patch must not be compatible (the bug this fixes).
+        assert!(!bump_is_compatible("2.0.5-alpha.0", "2.0.3").unwrap());
+        // Equal is not a compatible upgrade.
+        assert!(!bump_is_compatible("2.0.5-alpha.0", "2.0.5-alpha.0").unwrap());
+        // Release of the same major.minor.patch is a genuine upgrade (pre-release < release).
+        assert!(bump_is_compatible("2.0.5-alpha.0", "2.0.5").unwrap());
+        // A genuinely newer patch is compatible.
+        assert!(bump_is_compatible("2.0.5-alpha.0", "2.0.6").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Cuts 1.0.0-rc.3. Addresses the pre-release review findings on top of rc.2. Full `make ci` and `cargo clippy --all-features` are green.

## Breaking
- `build_async()` on the built-in backends returns a distinct per-backend `AsyncUpdate` wrapper exposing only the async (`*_async`) verbs as inherent methods, so a blocking `.update()` on an async-built updater is a compile error instead of silently blocking the executor.
- Rename the signature-key accessor `verify_keys()` -> `verifying_keys()`, matching the `verifying_keys(...)` setter (`signatures`).
- `Releases::is_update_available()` on a bare listing returns the new `Error::NoCurrentVersion` instead of `MissingField { field: "current_version" }`.

## Added
- `is_update_available_async()` on every backend's async updater.
- `max_download_size(bytes)` cap on `Download`.

## Fixed
- s3 `.release_tag("v1.2.3")` (v-prefixed) matches instead of failing with `NoReleaseFound`.
- custom backend `get_newer_releases()` filters to strictly-newer releases per the trait contract.
- GCS listings paginate past the first page (missing `list-type=2`).
- `version::bump_is_compatible` no longer treats a pre-release-to-older comparison as compatible.

## Security hardening
- host-gate a user-supplied `Authorization` header on next-page/download hosts.
- mask setuid/setgid/sticky bits from extracted zip modes.
- redact presigned s3 URLs in retry logs.
- bound listing-body size; reject `..` / path separators in a templated `bin_path_in_archive` before extraction.

## Docs
- deny broken intra-doc links; correct the async and `UpdateConfig`-import prose.
- update `CHANGELOG.md` and the 1.0 migration guides (`docs/migrations/0.x-to-1.0{,-human}.md`).

See `CHANGELOG.md` `[1.0.0]` and the migration guides for the two breaks and their migration notes.
