### PR TITLE
release 1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [unreleased]
 
+## [1.0.0-rc.4]
+API polish from a pre-1.0 consumer-experience review: three breaking changes (all folded into the
+[1.0 migration guide](docs/migrations/0.x-to-1.0-human.md)) plus additive constructors, inherent
+async verbs on the custom backend, and doc fixes.
+
+### Added
+- `Error::verification_rejected(reason)`: build the rejection a `verify_binary` hook returns. The
+  update pipeline surfaces an already-`VerificationRejected` hook error as-is instead of re-wrapping
+  it (other hook errors are still wrapped with their message as the reason).
+- The custom backend's `AsyncUpdate<S>` exposes the `*_async` verbs (`update_async`,
+  `update_extended_async`, `get_latest_release_async`, `get_newer_releases_async`,
+  `get_release_version_async`) as inherent methods, matching the built-in backends' `AsyncUpdate`
+  types; `use self_update::AsyncReleaseUpdate` is no longer needed to drive a custom async update.
+
+### Changed
+- `ReleaseSource::get_latest_releases` / `AsyncReleaseSource::get_latest_releases` renamed
+  `get_releases`: it returns the source's full unfiltered candidate list (newest-first), which the
+  old name misstated. Migration: rename the method in `ReleaseSource`/`AsyncReleaseSource` impls;
+  the updater's `get_newer_releases` (the filtered fetch) is unchanged.
+- The `ChecksumMismatch` and `NotFound` error variants are `#[non_exhaustive]`, matching every
+  other struct variant on `Error`. Migration: add `..` to struct patterns
+  (`Error::NotFound { url, .. }`); construct a 404 via `Error::http_status_error(404, url)`.
+- The single-release endpoints (github `/releases/latest` and `/releases/tags/{ver}`, gitlab/gitea
+  by-tag) surface an unparseable response body as `Error::InvalidResponse`, matching the listing
+  endpoints (previously `Error::Json`, so detecting "unparseable backend response" required
+  matching two variants). Migration: match `Error::InvalidResponse` where `Error::Json` was
+  matched on `get_latest_release`/`get_release_version` failures.
+
+### Fixed
+- Doc fixes: `Releases::from_listing` documented the pre-rc.3 `Error::MissingField` (now
+  `Error::NoCurrentVersion`); two `update.rs` trait docs still described `build()` as returning
+  `Box<dyn ReleaseUpdate>` (concrete `Update` since rc.2); the `ureq` feature bullet implied
+  reqwest/ureq are mutually exclusive; the migration-guide `match` examples destructured
+  `#[non_exhaustive]` variants without `..`.
+
 ## [1.0.0-rc.3]
 Further 1.0 surface changes on top of rc.2: two API breaks (closing the async-blocking footgun and
 aligning the signature-key accessor name), plus correctness, security-hardening, and doc fixes. The

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self_update"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 description = "Self updates for standalone executables"
 repository = "https://github.com/jaemk/self_update"
 keywords = ["update", "upgrade", "download", "release"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ At least one HTTP client must be selected; having zero clients is a compile erro
 clients and multiple TLS backends may coexist (reqwest is preferred when both are present):
 
 * `reqwest` (default): use the [`reqwest`](https://docs.rs/reqwest) HTTP client;
-* `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client instead (set `default-features = false`);
+* `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client, either alongside reqwest or as a drop-in replacement (set `default-features = false` to drop reqwest);
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
 
@@ -293,7 +293,7 @@ impl ReleaseSource for MyHost {
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
             .build()?)
     }
-    fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         Ok(vec![self.get_latest_release()?])
     }
     fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {

--- a/docs/migrations/0.x-to-1.0-human.md
+++ b/docs/migrations/0.x-to-1.0-human.md
@@ -120,15 +120,15 @@ match err {
     // ...one arm per variant...
 }
 
-// after
+// after (the struct variants are `#[non_exhaustive]`, so the patterns need `..`)
 match err {
     Error::Transport(e)                     => log::error!("transport: {e}"),
-    Error::NotFound { url }                 => log::error!("not found: {url}"),
-    Error::Unauthorized { status, url }     => log::error!("unauthorized {status}: {url}"),
-    Error::HttpStatus { status, url }       => log::error!("status {status}: {url}"),
-    Error::NoReleaseFound { target }        => log::error!("no release: {target:?}"),
-    Error::MissingAssetField { field }      => log::error!("missing field: {field}"),
-    Error::InvalidResponse { source }       => log::error!("bad response: {source}"),
+    Error::NotFound { url, .. }             => log::error!("not found: {url}"),
+    Error::Unauthorized { status, url, .. } => log::error!("unauthorized {status}: {url}"),
+    Error::HttpStatus { status, url, .. }   => log::error!("status {status}: {url}"),
+    Error::NoReleaseFound { target, .. }    => log::error!("no release: {target:?}"),
+    Error::MissingAssetField { field, .. }  => log::error!("missing field: {field}"),
+    Error::InvalidResponse { source, .. }   => log::error!("bad response: {source}"),
     _ => log::error!("other: {err}"), // required: the enum is now non_exhaustive
 }
 ```
@@ -468,7 +468,9 @@ The `verify_with` builder setter is renamed to `verify_binary`, and its callback
 
 Return `Ok(())` to accept the freshly-extracted binary and `Err(..)` to reject it. A rejection now
 produces `Error::VerificationRejected` (see section 2) rather than a generic `Error::Update`, so the
-failure reason can be carried. A `bool` could only say "rejected", not why.
+failure reason can be carried. A `bool` could only say "rejected", not why. Build the rejection with
+`Error::verification_rejected("reason")` (surfaced as-is); any other error returned from the hook is
+wrapped with its message as the reason.
 
 ## 9. The s3 endpoint type
 
@@ -500,7 +502,7 @@ that exposes only the `*_async` verbs as inherent methods (no `use self_update::
 import needed), so calling a blocking `.update()` on it is a compile error.
 
 - **Native async source:** implement the `AsyncReleaseSource` trait, the same three fetches, with
-  clean names (`get_latest_release`, `get_latest_releases`, `get_release_version`, **no** `_async`
+  clean names (`get_latest_release`, `get_releases`, `get_release_version`, **no** `_async`
   suffix). Drive it with the async custom updater:
 
   ```rust,ignore
@@ -531,20 +533,20 @@ import needed), so calling a blocking `.update()` on it is a compile error.
   construct it with `Blocking::new(source)` and read the wrapped source back with `into_inner()` /
   `as_inner()`.
 
-**`get_latest_releases` drops its `current_version` argument.** On both `ReleaseSource` and
-`AsyncReleaseSource`:
+**`get_latest_releases` is renamed `get_releases` and drops its `current_version` argument.** On
+both `ReleaseSource` and `AsyncReleaseSource`:
 
 ```rust
 // before
 fn get_latest_releases(&self, current_version: &str) -> Result<Vec<Release>> { .. }
 // after
-fn get_latest_releases(&self) -> Result<Vec<Release>> { .. }
+fn get_releases(&self) -> Result<Vec<Release>> { .. }
 ```
 
-The argument was unused on this path; the current version is carried by the updater, not the source.
-Note that `ReleaseSource::get_latest_releases` keeps its name: it returns the source's unfiltered
-candidate list. It is the updater's filtered fetch that was renamed to `get_newer_releases`
-(section 7); do not rename your source impl's methods.
+The argument was unused on this path; the current version is carried by the updater, not the
+source. The new name says what the method returns: the source's full unfiltered candidate list
+(newest-first), not just the "latest" ones. It is the *updater's* filtered fetch that was renamed
+to `get_newer_releases` (section 7) — the two are different methods with different semantics.
 There is also a new public `AsyncReleaseUpdate` trait (re-exported at the crate root under `async`),
 a sealed mirror of `ReleaseUpdate` for the async verbs, usable as a bound.
 

--- a/docs/migrations/0.x-to-1.0.md
+++ b/docs/migrations/0.x-to-1.0.md
@@ -149,12 +149,12 @@ match err {
     _ => {}
 }
 
-// after
+// after (the struct variants are `#[non_exhaustive]`, so the patterns need `..`)
 match err {
-    Error::NotFound { url }            => log::error!("not found: {url}"),
-    Error::Unauthorized { status, url } => log::error!("unauthorized {status}: {url}"),
-    Error::HttpStatus { status, url }   => log::error!("http status {status}: {url}"),
-    Error::Transport(e)                 => log::error!("transport: {e}"),
+    Error::NotFound { url, .. }            => log::error!("not found: {url}"),
+    Error::Unauthorized { status, url, .. } => log::error!("unauthorized {status}: {url}"),
+    Error::HttpStatus { status, url, .. }   => log::error!("http status {status}: {url}"),
+    Error::Transport(e)                     => log::error!("transport: {e}"),
     _ => {}
 }
 ```
@@ -324,8 +324,8 @@ Rewrite call sites:
   yields a `Releases`; read the newest via `.latest()` or take the list with `.into_vec()`.
 - `updater.get_latest_releases("1.2.3")?` -> `updater.get_newer_releases()?` (rename and drop the
   argument), then call `.all()` / `.into_vec()` for the `Vec<Release>` you previously got. NOTE:
-  this rename applies to the updater only; the custom-source `ReleaseSource::get_latest_releases`
-  keeps its name (see §9b).
+  this rename applies to the updater only; the custom-source method is separately renamed
+  `get_latest_releases` -> `get_releases` (see §9b).
 
 ## 3b. `Release` / `ReleaseAsset` fields are private; use getters (mechanical)
 
@@ -476,9 +476,13 @@ returned `true`, and `Err(...)` where it returned `false`:
 .verify_binary(|new_exe| run_version_check(new_exe))   // already returns Result<()>
 // or, mapping a bool:
 .verify_binary(|new_exe| if ok(new_exe) { Ok(()) } else {
-    Err(self_update::Error::Internal { message: "self-check failed".into(), source: None })
+    Err(self_update::Error::verification_rejected("self-check failed"))
 })
 ```
+
+`Error::verification_rejected(reason)` builds the rejection directly and is surfaced as-is; any
+other error returned from the hook is wrapped in a `VerificationRejected` whose `reason` is that
+error's message.
 
 Errors: `no method named `verify_with``; `expected ... bool, found ... Result` at the verify closure.
 
@@ -592,7 +596,7 @@ feature):
 - For a **natively-async** source, implement the
   [`AsyncReleaseSource`](https://docs.rs/self_update/latest/self_update/trait.AsyncReleaseSource.html)
   trait instead: the same three fetches with clean names (no `_async` suffix:
-  `get_latest_release`, `get_latest_releases`, `get_release_version`), and drive the update with
+  `get_latest_release`, `get_releases`, `get_release_version`), and drive the update with
   `self_update::backends::custom::AsyncUpdate::configure().source(..).build_async()?.update_async().await?`
   (mirrors a built-in backend's `build_async()`). The trait requires its returned futures to be
   `Send` (the methods return `impl Future<Output = ...> + Send`), enforced at the impl site rather
@@ -607,24 +611,24 @@ feature):
 `AsyncReleaseSource` is consumed through generics (`AsyncUpdate<S>`), never as a `dyn` object, so
 its futures need no `async-trait`/boxing.
 
-**9b. `get_latest_releases` drops its `current_version` argument.** On both `ReleaseSource` and
-`AsyncReleaseSource`, `get_latest_releases` no longer takes a `current_version`:
+**9b. `get_latest_releases` is renamed `get_releases` and drops its `current_version` argument.**
+On both `ReleaseSource` and `AsyncReleaseSource`:
 
 ```rust
 // before
 fn get_latest_releases(&self, current_version: &str) -> self_update::Result<Vec<Release>> { .. }
 // after
-fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> { .. }
+fn get_releases(&self) -> self_update::Result<Vec<Release>> { .. }
 ```
 
-Drop the parameter from your `impl` (the argument was unused on this path; the current version is
-carried by the updater, not the source) and from any direct call. Error:
-`method `get_latest_releases` has 1 parameter but the declaration ... has 0` /
-`this method takes 0 arguments but 1 argument was supplied`.
+Rename the method in your `impl` and drop the parameter (the argument was unused on this path; the
+current version is carried by the updater, not the source), and update any direct call. Errors:
+`not all trait items implemented, missing: `get_releases`` /
+`method `get_latest_releases` is not a member of trait `ReleaseSource``.
 
-NOTE: `ReleaseSource::get_latest_releases` KEEPS its name (it returns the source's unfiltered
-candidate list). Only the updater/`ReleaseUpdate` filtered fetch was renamed `get_newer_releases`
-(§3a); do not apply that rename to a `ReleaseSource` / `AsyncReleaseSource` impl.
+NOTE: this is a different method from the updater/`ReleaseUpdate` filtered fetch, which was renamed
+`get_newer_releases` (§3a). The source method returns the unfiltered candidate list (newest-first);
+the updater method returns the strictly-newer subset.
 
 A source builds the `#[non_exhaustive]` release-flow error variants via the public constructors
 `Error::no_release_found(target)`, `Error::missing_asset_field(field)`,
@@ -699,10 +703,11 @@ A successful build with no `self_update`-related errors means the migration is c
 | `no method named `updated`` on a `VersionStatus`/`ReleaseStatus` | §2a (now `is_updated`) |
 | `mismatched types: expected bool, found Option<Release>` near `is_update_available` | §3a (now returns `Result<Option<Release>>`; test with `.is_some()`) |
 | `no method named `is_update_available_async`` on an updater | §3a (removed; use `get_latest_release_async().await?.is_update_available()`) |
-| `no method named `get_latest_releases`` on an updater / concrete `Update` | §3a (renamed `get_newer_releases`; the `ReleaseSource` method keeps the name, §9b) |
+| `no method named `get_latest_releases`` on an updater / concrete `Update` | §3a (renamed `get_newer_releases`; the `ReleaseSource` method is separately renamed `get_releases`, §9b) |
 | `mismatched types: expected `Release`/`Vec<Release>`, found `Releases`` near `get_latest_release`/`get_newer_releases`/`fetch` | §3a (now return `Releases`; use `.latest()` / `.all()` / `.into_vec()`) |
 | `mismatched types: expected ... Box<dyn ReleaseUpdate>` at `build()` | §3a (`build()` returns the concrete `Update`; drop or update the annotation) |
-| `this method takes 0 arguments but 1 argument was supplied` at `get_latest_releases(` / `get_newer_releases(` | §3a (updater; also renamed) / §9b (custom source) (drop the `current_version` argument) |
+| `this method takes 0 arguments but 1 argument was supplied` at `get_releases(` / `get_newer_releases(` | §3a (updater; also renamed) / §9b (custom source; renamed `get_releases`) (drop the `current_version` argument) |
+| `not all trait items implemented, missing: `get_releases`` on a `ReleaseSource`/`AsyncReleaseSource` impl | §9b (rename `get_latest_releases` -> `get_releases`) |
 | `the trait `ReleaseUpdate` cannot be implemented` / sealed-trait error | §4 |
 | `no HTTP client selected` (compile_error) | §5.4 |
 | `no method named `verify_with`` | §6a (now `verify_binary`, returns `Result<()>`) |

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -44,7 +44,7 @@ impl ReleaseSource for MyHost {
             .build()
     }
 
-    fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         // Return the full candidate list. The updater discards releases that are not
         // strictly newer than the current version and picks the newest semver-compatible
         // one, so you do not need to pre-filter by `current`.
@@ -80,7 +80,7 @@ impl ReleaseSource for MyHost {
 #[allow(dead_code)]
 mod async_update {
     use self_update::backends::custom::{AsyncUpdate, Blocking};
-    use self_update::{AsyncReleaseSource, AsyncReleaseUpdate, Release, ReleaseAsset};
+    use self_update::{AsyncReleaseSource, Release, ReleaseAsset};
 
     // A natively-async source: implement `AsyncReleaseSource` when your listing
     // transport is already async (e.g. you hold a `reqwest::Client`).
@@ -98,7 +98,7 @@ mod async_update {
                 .build()
         }
 
-        async fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+        async fn get_releases(&self) -> self_update::Result<Vec<Release>> {
             Ok(vec![self.get_latest_release().await?])
         }
 

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -21,7 +21,7 @@ impl ReleaseSource for MyHost {
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
             .build()?)
     }
-    fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         Ok(vec![self.get_latest_release()?])
     }
     fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
@@ -60,7 +60,7 @@ transport, implement [`AsyncReleaseSource`](crate::AsyncReleaseSource) and drive
 ```no_run
 # #[cfg(feature = "async")]
 # mod demo {
-use self_update::{AsyncReleaseSource, AsyncReleaseUpdate, Release, ReleaseAsset, cargo_crate_version};
+use self_update::{AsyncReleaseSource, Release, ReleaseAsset, cargo_crate_version};
 use self_update::backends::custom::AsyncUpdate;
 
 struct MyHost;
@@ -72,7 +72,7 @@ impl AsyncReleaseSource for MyHost {
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
             .build()?)
     }
-    async fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+    async fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         Ok(vec![self.get_latest_release().await?])
     }
     async fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
@@ -104,7 +104,7 @@ use self_update::backends::custom::{AsyncUpdate, Blocking};
 # struct MySyncHost;
 # impl self_update::ReleaseSource for MySyncHost {
 #     fn get_latest_release(&self) -> self_update::Result<self_update::Release> { unimplemented!() }
-#     fn get_latest_releases(&self) -> self_update::Result<Vec<self_update::Release>> { unimplemented!() }
+#     fn get_releases(&self) -> self_update::Result<Vec<self_update::Release>> { unimplemented!() }
 #     fn get_release_version(&self, _: &str) -> self_update::Result<self_update::Release> { unimplemented!() }
 # }
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -226,7 +226,7 @@ impl ReleaseUpdate for Update {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = self
             .source
-            .get_latest_releases()?
+            .get_releases()?
             .into_iter()
             .filter(|r| {
                 crate::version::bump_is_greater(&current_version, r.version()).unwrap_or(false)
@@ -310,7 +310,9 @@ impl<S: crate::update::AsyncReleaseSource> AsyncUpdateBuilder<S> {
 /// Async sibling of [`Update`]: updates to a specified or latest release from a user-defined
 /// [`AsyncReleaseSource`](crate::AsyncReleaseSource).
 ///
-/// Generic over the source (no trait object), so the source's `async fn`s need no boxing.
+/// Generic over the source (no trait object), so the source's `async fn`s need no boxing. Like the
+/// built-in backends' `AsyncUpdate` types, the `*_async` verbs are inherent methods — no
+/// `AsyncReleaseUpdate` import is needed to call them.
 #[cfg(feature = "async")]
 #[non_exhaustive]
 pub struct AsyncUpdate<S: crate::update::AsyncReleaseSource> {
@@ -333,6 +335,37 @@ impl<S: crate::update::AsyncReleaseSource> AsyncUpdate<S> {
     /// Initialize a new [`AsyncUpdate`] builder.
     pub fn configure() -> AsyncUpdateBuilder<S> {
         AsyncUpdateBuilder::new()
+    }
+
+    /// Display release information and update the current binary to the latest release,
+    /// pending confirmation. Returns a [`VersionStatus`](crate::VersionStatus). See
+    /// [`AsyncReleaseUpdate::update_async`](crate::AsyncReleaseUpdate::update_async).
+    pub async fn update_async(&self) -> Result<crate::VersionStatus> {
+        crate::update::AsyncReleaseUpdate::update_async(self).await
+    }
+
+    /// Same as [`update_async`](Self::update_async) but returns a
+    /// [`ReleaseStatus`](crate::ReleaseStatus) with the full release details.
+    pub async fn update_extended_async(&self) -> Result<crate::ReleaseStatus> {
+        crate::update::AsyncReleaseUpdate::update_extended_async(self).await
+    }
+
+    /// Fetch the single newest release from the source. See
+    /// [`AsyncReleaseUpdate::get_latest_release_async`](crate::AsyncReleaseUpdate::get_latest_release_async).
+    pub async fn get_latest_release_async(&self) -> Result<Releases> {
+        crate::update::AsyncReleaseUpdate::get_latest_release_async(self).await
+    }
+
+    /// Fetch the releases newer than the current version. See
+    /// [`AsyncReleaseUpdate::get_newer_releases_async`](crate::AsyncReleaseUpdate::get_newer_releases_async).
+    pub async fn get_newer_releases_async(&self) -> Result<Releases> {
+        crate::update::AsyncReleaseUpdate::get_newer_releases_async(self).await
+    }
+
+    /// Fetch details of the release matching `ver`. See
+    /// [`AsyncReleaseUpdate::get_release_version_async`](crate::AsyncReleaseUpdate::get_release_version_async).
+    pub async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
+        crate::update::AsyncReleaseUpdate::get_release_version_async(self, ver).await
     }
 
     /// Whether a release newer than the current version is available, returning it if so.
@@ -369,7 +402,7 @@ impl<S: crate::update::AsyncReleaseSource> crate::update::AsyncReleaseUpdate for
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = self
             .source
-            .get_latest_releases()
+            .get_releases()
             .await?
             .into_iter()
             .filter(|r| {
@@ -422,9 +455,9 @@ impl<S: ReleaseSource + Clone + 'static> crate::update::AsyncReleaseSource for B
                 source: Some(Box::new(e)),
             })?
     }
-    async fn get_latest_releases(&self) -> Result<Vec<Release>> {
+    async fn get_releases(&self) -> Result<Vec<Release>> {
         let s = self.source.clone();
-        tokio::task::spawn_blocking(move || s.get_latest_releases())
+        tokio::task::spawn_blocking(move || s.get_releases())
             .await
             .map_err(|e| Error::Internal {
                 message: "blocking task failed".to_string(),
@@ -466,7 +499,7 @@ mod tests {
                 ))
                 .build()
         }
-        fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+        fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
             Ok(vec![self.get_latest_release()?])
         }
         fn get_release_version(&self, ver: &str) -> crate::errors::Result<Release> {
@@ -532,7 +565,7 @@ mod tests {
         let tagged = upd.get_release_version("1.5.0").unwrap();
         assert_eq!(tagged.version(), "1.5.0");
 
-        // get_latest_release once + once inside get_latest_releases = 2.
+        // get_latest_release once + once inside get_releases = 2.
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
@@ -595,7 +628,7 @@ mod tests {
         fn get_latest_release(&self) -> crate::errors::Result<Release> {
             Release::builder().version("3.0.0").build()
         }
-        fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+        fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
             Ok(vec![
                 Release::builder().version("3.0.0").build()?,
                 Release::builder().version("2.0.0").build()?,
@@ -684,7 +717,7 @@ mod tests {
     // submodule below. The async tests proved those paths work through `AsyncUpdate`; the tests here
     // prove the same paths work through the sync `Update` and its `update_extended()` orchestrator.
 
-    /// A sync source whose `get_latest_releases` returns several candidates (out of order, some
+    /// A sync source whose `get_releases` returns several candidates (out of order, some
     /// older than current) so `choose_latest_release` runs over real source data. Each release
     /// carries a single asset whose name embeds its version (`app-<ver>.bin`), letting an
     /// asset-matcher report which release the orchestrator actually selected.
@@ -705,7 +738,7 @@ mod tests {
         fn get_latest_release(&self) -> crate::errors::Result<Release> {
             self.get_release_version("9.9.9")
         }
-        fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+        fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
             // Newest-but-incompatible, current, older, and the compatible winner — out of order.
             // The orchestrator must drop current/older and pick the newest compatible (1.4.0),
             // not 2.0.0 and not 1.0.0.
@@ -833,7 +866,7 @@ mod tests {
                     ))
                     .build()
             }
-            async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+            async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                 tokio::task::yield_now().await;
                 self.releases_calls.fetch_add(1, Ordering::SeqCst);
                 Ok(vec![Release::builder().version("2.0.0").build()?])
@@ -918,7 +951,7 @@ mod tests {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 Release::builder().version("3.0.0").build()
             }
-            fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+            fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 Ok(vec![Release::builder().version("3.0.0").build()?])
             }
@@ -974,7 +1007,7 @@ mod tests {
             );
         }
 
-        /// An end-to-end async source whose `get_latest_releases` returns several candidates
+        /// An end-to-end async source whose `get_releases` returns several candidates
         /// (out of order, some older than current) so the async orchestrator's
         /// `choose_latest_release` selection runs over real source data. Each release carries a
         /// single asset whose name embeds its version (`app-<ver>.bin`), so a downstream
@@ -996,7 +1029,7 @@ mod tests {
             async fn get_latest_release(&self) -> crate::errors::Result<Release> {
                 self.get_release_version("9.9.9").await
             }
-            async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+            async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                 tokio::task::yield_now().await;
                 // Newest-but-incompatible, current, older, and the compatible winner — out of
                 // order. The orchestrator must drop current/older and pick the newest compatible
@@ -1024,7 +1057,7 @@ mod tests {
                 async fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     Release::builder().version("1.0.0").build()
                 }
-                async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     tokio::task::yield_now().await;
                     Ok(vec![
                         Release::builder().version("1.0.0").build()?,
@@ -1147,7 +1180,7 @@ mod tests {
                 async fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     Release::builder().version("1.0.0").build()
                 }
-                async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     Ok(vec![Release::builder().version("1.0.0").build()?])
                 }
                 async fn get_release_version(&self, ver: &str) -> crate::errors::Result<Release> {
@@ -1183,7 +1216,7 @@ mod tests {
                 fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     Err(crate::errors::Error::NoReleaseFound { target: None })
                 }
-                fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     Err(crate::errors::Error::HttpStatus {
                         status: 503,
                         url: "u".into(),
@@ -1200,7 +1233,7 @@ mod tests {
                 Err(crate::errors::Error::NoReleaseFound { .. })
             ));
             assert!(matches!(
-                AsyncReleaseSource::get_latest_releases(&blk).await,
+                AsyncReleaseSource::get_releases(&blk).await,
                 Err(crate::errors::Error::HttpStatus { .. })
             ));
             assert!(matches!(
@@ -1221,7 +1254,7 @@ mod tests {
                 fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     panic!("boom in blocking task");
                 }
-                fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     unreachable!()
                 }
                 fn get_release_version(&self, _ver: &str) -> crate::errors::Result<Release> {
@@ -1255,7 +1288,7 @@ mod tests {
                 fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     Release::builder().version("1.0.0").build()
                 }
-                fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     Ok(vec![])
                 }
                 fn get_release_version(&self, v: &str) -> crate::errors::Result<Release> {
@@ -1368,7 +1401,7 @@ mod tests {
             async fn get_latest_release(&self) -> crate::errors::Result<Release> {
                 Release::builder().version("3.0.0").build()
             }
-            async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+            async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                 Ok(vec![
                     Release::builder().version("3.0.0").build()?,
                     Release::builder().version("2.0.0").build()?,
@@ -1487,7 +1520,7 @@ mod tests {
                 async fn get_latest_release(&self) -> crate::errors::Result<Release> {
                     self.get_release_version("9.9.9").await
                 }
-                async fn get_latest_releases(&self) -> crate::errors::Result<Vec<Release>> {
+                async fn get_releases(&self) -> crate::errors::Result<Vec<Release>> {
                     tokio::task::yield_now().await;
                     Ok(vec![
                         Release::builder()

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -530,7 +530,9 @@ fn single_plan(url: String) -> Result<PageRequest<Release>> {
         url,
         headers,
         parse: Box::new(|body, _resp_headers| {
-            let dto: ReleaseDto = serde_json::from_slice(body)?;
+            // An unparseable body is `InvalidResponse`, matching the paginated listing parser.
+            let dto: ReleaseDto =
+                serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
             Ok(Page::last(vec![dto.into_release()?]))
         }),
     })
@@ -599,6 +601,19 @@ mod tests {
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
         crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
+    }
+
+    // The single-release endpoint (`.../releases/tags/{ver}`) surfaces an unparseable body as
+    // `InvalidResponse`, matching the paginated listing parser (previously `Error::Json`).
+    #[test]
+    fn single_plan_parse_failure_is_invalid_response() {
+        let req =
+            super::single_plan("https://example.test/releases/tags/1.0.0".to_string()).unwrap();
+        let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
+        assert!(
+            matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
+            "a malformed single-release body must map to InvalidResponse"
+        );
     }
 
     use std::io::{Read, Write};

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -156,7 +156,6 @@ impl ReleaseListBuilder {
                 return Err(Error::MissingField { field: "repo_name" });
             },
             target: self.target.clone(),
-            auth_token: self.auth_token.clone(),
             custom_url: self.custom_url.clone(),
             request,
         })
@@ -170,7 +169,6 @@ pub struct ReleaseList {
     repo_owner: String,
     repo_name: String,
     target: Option<String>,
-    auth_token: Option<String>,
     custom_url: Option<String>,
     request: RequestConfig,
 }
@@ -203,10 +201,7 @@ impl ReleaseList {
             self.repo_name
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = run_paginated(
-            releases_plan(&api_url, self.auth_token.as_deref(), None)?,
-            &self.request,
-        )?;
+        let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -229,11 +224,9 @@ impl ReleaseList {
             self.repo_name
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = crate::backends::run_paginated_async(
-            releases_plan(&api_url, self.auth_token.as_deref(), None)?,
-            &self.request,
-        )
-        .await?;
+        let releases =
+            crate::backends::run_paginated_async(releases_plan(&api_url, None)?, &self.request)
+                .await?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -400,10 +393,7 @@ impl Update {
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated(
-            single_plan(self.latest_url(), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )?;
+        let releases = run_paginated(single_plan(self.latest_url())?, &self.common.request)?;
         let release = releases
             .into_iter()
             .next()
@@ -414,21 +404,14 @@ impl ReleaseUpdate for Update {
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated(
-            releases_plan(
-                &self.releases_url(),
-                self.common.auth_token.as_deref(),
-                Some(&current_version),
-            )?,
+            releases_plan(&self.releases_url(), Some(&current_version))?,
             &self.common.request,
         )?;
         Ok(Releases::new(releases, current_version))
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        let releases = run_paginated(
-            single_plan(self.tag_url(ver), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )?;
+        let releases = run_paginated(single_plan(self.tag_url(ver))?, &self.common.request)?;
         releases
             .into_iter()
             .next()
@@ -465,18 +448,12 @@ impl_update_config_accessors!(Update, {
 /// regardless (a backport release — older semver, newer creation date — must not halt the walk
 /// and cause a genuinely newer release on a later page to be missed). When `None` the listing is
 /// unfiltered and every page is walked (used by `ReleaseList`).
-fn releases_plan(
-    base_url: &str,
-    auth_token: Option<&str>,
-    stop_at: Option<&str>,
-) -> Result<PageRequest<Release>> {
+fn releases_plan(base_url: &str, stop_at: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
-    let auth = auth_token.map(str::to_owned);
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
         first_page_url(base_url),
         headers,
-        auth,
         stop_at,
     ))
 }
@@ -485,7 +462,6 @@ fn releases_plan(
 fn release_array_page(
     url: String,
     headers: HeaderMap,
-    auth: Option<String>,
     stop_at: Option<String>,
 ) -> PageRequest<Release> {
     PageRequest {
@@ -511,9 +487,8 @@ fn release_array_page(
                 }
                 items.push(release);
             }
-            let next = next_link(resp_headers).map(|next_url| {
-                release_array_page(next_url, api_headers_for(), auth.clone(), stop_at.clone())
-            });
+            let next = next_link(resp_headers)
+                .map(|next_url| release_array_page(next_url, api_headers_for(), stop_at.clone()));
             Ok(Page {
                 items,
                 next,
@@ -525,15 +500,17 @@ fn release_array_page(
 
 /// Transport-free plan to fetch a single release *object* (the `/releases/latest` and
 /// `/releases/tags/{ver}` endpoints), parsed via the private `ReleaseDto` into a one-item page.
-fn single_plan(url: String, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+fn single_plan(url: String) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     Ok(PageRequest {
         url,
         headers,
         parse: Box::new(|body, _resp_headers| {
             // The single-release endpoints return a bare release object; deserialize it directly
-            // into the DTO and convert.
-            let dto: ReleaseDto = serde_json::from_slice(body)?;
+            // into the DTO and convert. An unparseable body is `InvalidResponse`, matching the
+            // paginated listing parser.
+            let dto: ReleaseDto =
+                serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
             Ok(Page::last(vec![dto.into_release()?]))
         }),
     })
@@ -552,11 +529,8 @@ impl crate::update::AsyncReleaseUpdate for Update {
     async fn get_latest_release_async(&self) -> Result<Releases> {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated_async(
-            single_plan(self.latest_url(), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )
-        .await?;
+        let releases =
+            run_paginated_async(single_plan(self.latest_url())?, &self.common.request).await?;
         let release = releases
             .into_iter()
             .next()
@@ -568,11 +542,7 @@ impl crate::update::AsyncReleaseUpdate for Update {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated_async(
-            releases_plan(
-                &self.releases_url(),
-                self.common.auth_token.as_deref(),
-                Some(&current_version),
-            )?,
+            releases_plan(&self.releases_url(), Some(&current_version))?,
             &self.common.request,
         )
         .await?;
@@ -581,11 +551,8 @@ impl crate::update::AsyncReleaseUpdate for Update {
 
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
         use crate::backends::run_paginated_async;
-        let releases = run_paginated_async(
-            single_plan(self.tag_url(ver), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )
-        .await?;
+        let releases =
+            run_paginated_async(single_plan(self.tag_url(ver))?, &self.common.request).await?;
         releases
             .into_iter()
             .next()
@@ -623,25 +590,35 @@ mod tests {
     // sealed `UpdateConfig` trait; bring it into scope so they resolve on the concrete `Update`.
     use crate::update::UpdateConfig;
 
+    // The single-release endpoints (`/releases/latest`, `/releases/tags/{ver}`) surface an
+    // unparseable body as `InvalidResponse`, matching the paginated listing parser (previously
+    // they mapped to `Error::Json`, forcing callers to match two variants for one failure).
+    #[test]
+    fn single_plan_parse_failure_is_invalid_response() {
+        let req = super::single_plan("https://example.test/releases/latest".to_string()).unwrap();
+        let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
+        assert!(
+            matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
+            "a malformed single-release body must map to InvalidResponse"
+        );
+    }
+
     /// Test wrapper: drive the sans-io `releases_plan` through the sync `run_paginated` driver.
     /// `stop_at = None` => walk all pages (the unfiltered listing behavior).
     fn fetch_all_releases(
         base_url: &str,
-        auth_token: Option<&str>,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated(super::releases_plan(base_url, auth_token, None)?, req)
+        crate::backends::run_paginated(super::releases_plan(base_url, None)?, req)
     }
 
     /// Async test wrapper over `releases_plan` + the async driver. `stop_at = None`.
     #[cfg(feature = "async")]
     async fn fetch_all_releases_async(
         base_url: &str,
-        auth_token: Option<&str>,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated_async(super::releases_plan(base_url, auth_token, None)?, req)
-            .await
+        crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
     }
 
     struct Resp {
@@ -1048,7 +1025,6 @@ mod tests {
         });
         let releases = fetch_all_releases_async(
             &format!("{base}/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .await
@@ -1290,7 +1266,6 @@ mod tests {
         });
         let releases = fetch_all_releases(
             &format!("{base}/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .unwrap();
@@ -1314,7 +1289,6 @@ mod tests {
         });
         let res = fetch_all_releases(
             &format!("{base}/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         );
         // A non-2xx status always produces a structured status variant (NotFound /
@@ -1338,7 +1312,6 @@ mod tests {
         });
         let res = fetch_all_releases(
             &format!("{base}/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         );
         assert!(
@@ -1772,7 +1745,7 @@ mod tests {
             )),
             ..Default::default()
         };
-        let releases = fetch_all_releases(&format!("{base}/releases"), None, &cfg).unwrap();
+        let releases = fetch_all_releases(&format!("{base}/releases"), &cfg).unwrap();
         assert_eq!(releases.len(), 1);
         assert_eq!(releases[0].version(), "1.2.3");
         let request = captured.lock().unwrap()[0].to_lowercase();
@@ -1818,7 +1791,7 @@ mod tests {
             )),
             ..Default::default()
         };
-        let releases = fetch_all_releases_async(&format!("{base}/releases"), None, &cfg)
+        let releases = fetch_all_releases_async(&format!("{base}/releases"), &cfg)
             .await
             .unwrap();
         assert_eq!(releases.len(), 1);
@@ -1860,7 +1833,7 @@ mod tests {
             ))),
             ..Default::default()
         };
-        let releases = fetch_all_releases(&format!("{base}/releases"), None, &cfg).unwrap();
+        let releases = fetch_all_releases(&format!("{base}/releases"), &cfg).unwrap();
         assert_eq!(releases.len(), 1);
         assert_eq!(releases[0].version(), "3.0.0");
     }
@@ -1922,8 +1895,7 @@ mod tests {
             })),
             ..Default::default()
         };
-        let releases =
-            fetch_all_releases("https://example.test/repos/o/r/releases", None, &cfg).unwrap();
+        let releases = fetch_all_releases("https://example.test/repos/o/r/releases", &cfg).unwrap();
         assert_eq!(releases.len(), 1);
         assert_eq!(
             releases[0].version(),
@@ -1981,7 +1953,7 @@ mod tests {
             headers,
             ..Default::default()
         };
-        let releases = fetch_all_releases(&format!("{base}/releases"), None, &cfg).unwrap();
+        let releases = fetch_all_releases(&format!("{base}/releases"), &cfg).unwrap();
         assert_eq!(releases.len(), 1);
         let request = captured.lock().unwrap()[0].to_lowercase();
         assert!(
@@ -2007,7 +1979,7 @@ mod tests {
             ..Default::default()
         };
         let start = Instant::now();
-        let res = fetch_all_releases(&format!("{base}/releases"), None, &cfg);
+        let res = fetch_all_releases(&format!("{base}/releases"), &cfg);
         assert!(res.is_err(), "expected a timeout error");
         assert!(
             start.elapsed() < Duration::from_secs(3),
@@ -2043,7 +2015,7 @@ mod tests {
             retries: 2,
             ..Default::default()
         };
-        let releases = fetch_all_releases(&format!("{base}/releases"), None, &cfg).unwrap();
+        let releases = fetch_all_releases(&format!("{base}/releases"), &cfg).unwrap();
         assert_eq!(releases.len(), 1);
         assert_eq!(releases[0].version(), "1.0.0");
     }
@@ -2070,7 +2042,7 @@ mod tests {
             retries: 1,
             ..Default::default()
         };
-        let res = fetch_all_releases(&format!("{base}/releases"), None, &cfg);
+        let res = fetch_all_releases(&format!("{base}/releases"), &cfg);
         assert!(res.is_err());
     }
 
@@ -2259,7 +2231,6 @@ mod tests {
         });
         let releases = fetch_all_releases(
             &format!("{base}/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .unwrap();

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -168,7 +168,6 @@ impl ReleaseListBuilder {
                 return Err(Error::MissingField { field: "repo_name" });
             },
             target: self.target.clone(),
-            auth_token: self.auth_token.clone(),
             request,
         })
     }
@@ -182,7 +181,6 @@ pub struct ReleaseList {
     repo_owner: String,
     repo_name: String,
     target: Option<String>,
-    auth_token: Option<String>,
     request: RequestConfig,
 }
 impl ReleaseList {
@@ -212,10 +210,7 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = run_paginated(
-            releases_plan(&api_url, self.auth_token.as_deref(), None)?,
-            &self.request,
-        )?;
+        let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -236,11 +231,9 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = crate::backends::run_paginated_async(
-            releases_plan(&api_url, self.auth_token.as_deref(), None)?,
-            &self.request,
-        )
-        .await?;
+        let releases =
+            crate::backends::run_paginated_async(releases_plan(&api_url, None)?, &self.request)
+                .await?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -386,10 +379,7 @@ impl Update {
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated(
-            newest_plan(&self.releases_url(), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )?;
+        let releases = run_paginated(newest_plan(&self.releases_url())?, &self.common.request)?;
         let release = releases
             .into_iter()
             .next()
@@ -400,21 +390,14 @@ impl ReleaseUpdate for Update {
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated(
-            releases_plan(
-                &self.releases_url(),
-                self.common.auth_token.as_deref(),
-                Some(&current_version),
-            )?,
+            releases_plan(&self.releases_url(), Some(&current_version))?,
             &self.common.request,
         )?;
         Ok(Releases::new(releases, current_version))
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        let releases = run_paginated(
-            single_plan(self.tag_url(ver), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )?;
+        let releases = run_paginated(single_plan(self.tag_url(ver))?, &self.common.request)?;
         releases
             .into_iter()
             .next()
@@ -458,18 +441,12 @@ impl Default for UpdateBuilder {
 /// via the private `ReleaseDto` and following `Link: rel="next"`. `stop_at` filters per-item
 /// (releases not strictly newer are omitted but pagination continues); when `None` all pages are
 /// walked unfiltered.
-fn releases_plan(
-    base_url: &str,
-    auth_token: Option<&str>,
-    stop_at: Option<&str>,
-) -> Result<PageRequest<Release>> {
+fn releases_plan(base_url: &str, stop_at: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
-    let auth = auth_token.map(str::to_owned);
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
         first_page_url(base_url),
         headers,
-        auth,
         stop_at,
     ))
 }
@@ -477,7 +454,6 @@ fn releases_plan(
 fn release_array_page(
     url: String,
     headers: HeaderMap,
-    auth: Option<String>,
     stop_at: Option<String>,
 ) -> PageRequest<Release> {
     PageRequest {
@@ -507,7 +483,6 @@ fn release_array_page(
                 release_array_page(
                     next_url,
                     api_headers().expect("api_headers builds from static values"),
-                    auth.clone(),
                     stop_at.clone(),
                 )
             });
@@ -522,7 +497,7 @@ fn release_array_page(
 
 /// Transport-free plan for the newest release: GitLab has no `/releases/latest`, so the listing's
 /// first element (newest-first order) is "latest". Fetches just the first page (no pagination).
-fn newest_plan(base_url: &str, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+fn newest_plan(base_url: &str) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     Ok(PageRequest {
         url: first_page_url(base_url),
@@ -542,13 +517,15 @@ fn newest_plan(base_url: &str, _auth_token: Option<&str>) -> Result<PageRequest<
 }
 
 /// Transport-free plan to fetch a single release *object* (the `.../releases/{ver}` endpoint).
-fn single_plan(url: String, _auth_token: Option<&str>) -> Result<PageRequest<Release>> {
+fn single_plan(url: String) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     Ok(PageRequest {
         url,
         headers,
         parse: Box::new(|body, _resp_headers| {
-            let dto: ReleaseDto = serde_json::from_slice(body)?;
+            // An unparseable body is `InvalidResponse`, matching the paginated listing parser.
+            let dto: ReleaseDto =
+                serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
             Ok(Page::last(vec![dto.into_release()?]))
         }),
     })
@@ -559,11 +536,8 @@ impl crate::update::AsyncReleaseUpdate for Update {
     async fn get_latest_release_async(&self) -> Result<Releases> {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated_async(
-            newest_plan(&self.releases_url(), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )
-        .await?;
+        let releases =
+            run_paginated_async(newest_plan(&self.releases_url())?, &self.common.request).await?;
         let release = releases
             .into_iter()
             .next()
@@ -575,11 +549,7 @@ impl crate::update::AsyncReleaseUpdate for Update {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated_async(
-            releases_plan(
-                &self.releases_url(),
-                self.common.auth_token.as_deref(),
-                Some(&current_version),
-            )?,
+            releases_plan(&self.releases_url(), Some(&current_version))?,
             &self.common.request,
         )
         .await?;
@@ -588,11 +558,8 @@ impl crate::update::AsyncReleaseUpdate for Update {
 
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
         use crate::backends::run_paginated_async;
-        let releases = run_paginated_async(
-            single_plan(self.tag_url(ver), self.common.auth_token.as_deref())?,
-            &self.common.request,
-        )
-        .await?;
+        let releases =
+            run_paginated_async(single_plan(self.tag_url(ver))?, &self.common.request).await?;
         releases
             .into_iter()
             .next()
@@ -623,11 +590,21 @@ mod tests {
     #[cfg(feature = "async")]
     async fn fetch_all_releases_async(
         base_url: &str,
-        auth_token: Option<&str>,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated_async(super::releases_plan(base_url, auth_token, None)?, req)
-            .await
+        crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
+    }
+
+    // The single-release endpoint (`.../releases/{ver}`) surfaces an unparseable body as
+    // `InvalidResponse`, matching the paginated listing parser (previously `Error::Json`).
+    #[test]
+    fn single_plan_parse_failure_is_invalid_response() {
+        let req = super::single_plan("https://example.test/releases/1.0.0".to_string()).unwrap();
+        let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
+        assert!(
+            matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
+            "a malformed single-release body must map to InvalidResponse"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -820,7 +797,6 @@ mod tests {
         });
         let releases = fetch_all_releases_async(
             &format!("{base}/api/v4/projects/o%2Fr/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .await
@@ -1235,7 +1211,6 @@ mod tests {
         });
         let res = fetch_all_releases_async(
             &format!("{base}/api/v4/projects/o%2Fr/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .await;
@@ -1264,7 +1239,6 @@ mod tests {
         });
         let res = fetch_all_releases_async(
             &format!("{base}/api/v4/projects/o%2Fr/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .await;
@@ -1290,7 +1264,6 @@ mod tests {
         });
         let releases = fetch_all_releases_async(
             &format!("{base}/api/v4/projects/o%2Fr/releases"),
-            None,
             &crate::backends::common::RequestConfig::default(),
         )
         .await

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1563,7 +1563,7 @@ fn parse_s3_response<R: std::io::BufRead>(
                                 release.assets = vec![ReleaseAsset::new(exe_name, download_url)];
                                 debug!("Matched release: {:?}", release);
                             } else {
-                                debug!("Regex mismatch: {:?}", &txt);
+                                debug!("Regex mismatch: {:?}", txt);
                             }
                         }
                         Tag::LastModified => {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,6 +48,7 @@ pub enum Error {
     ///
     /// `expected` is the configured digest; `computed` is the one actually produced from the
     /// downloaded file. Both are hex-encoded lowercase digests.
+    #[non_exhaustive]
     ChecksumMismatch {
         /// The expected digest (from the configured `Checksum`), hex-encoded.
         expected: String,
@@ -62,6 +63,7 @@ pub enum Error {
     /// A request completed and returned HTTP 404 (resource not found).
     ///
     /// `url` is the request URL that produced the 404.
+    #[non_exhaustive]
     NotFound {
         /// The URL whose response was HTTP 404.
         url: String,
@@ -289,6 +291,30 @@ impl Error {
     /// `Unauthorized` for 401/403, else `HttpStatus`.
     pub fn http_status_error(status: u16, url: impl Into<String>) -> Error {
         status_to_error(status, &url.into())
+    }
+
+    /// Construct a [`VerificationRejected`](Error::VerificationRejected) error with the given
+    /// reason, for rejecting the extracted binary from a `verify_binary` hook:
+    ///
+    /// ```rust
+    /// # fn check(path: &std::path::Path) -> bool { true }
+    /// # let hook =
+    /// |path: &std::path::Path| {
+    ///     if check(path) {
+    ///         Ok(())
+    ///     } else {
+    ///         Err(self_update::Error::verification_rejected("new binary failed --version"))
+    ///     }
+    /// }
+    /// # ;
+    /// ```
+    ///
+    /// The update pipeline surfaces this error as-is; any *other* error returned from the hook is
+    /// wrapped in a `VerificationRejected` whose `reason` is that error's message.
+    pub fn verification_rejected(reason: impl Into<String>) -> Error {
+        Error::VerificationRejected {
+            reason: Some(reason.into()),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ At least one HTTP client must be selected; having zero clients is a compile erro
 clients and multiple TLS backends may coexist (reqwest is preferred when both are present):
 
 * `reqwest` (default): use the [`reqwest`](https://docs.rs/reqwest) HTTP client;
-* `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client instead (set `default-features = false`);
+* `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client, either alongside reqwest or as a drop-in replacement (set `default-features = false` to drop reqwest);
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
 
@@ -298,7 +298,7 @@ impl ReleaseSource for MyHost {
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
             .build()?)
     }
-    fn get_latest_releases(&self) -> self_update::Result<Vec<Release>> {
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         Ok(vec![self.get_latest_release()?])
     }
     fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -647,8 +647,10 @@ macro_rules! impl_common_builder_setters {
         /// of the archive) -> signature ([`verifying_keys`](Self::verifying_keys), over the archive) ->
         /// extract -> `verify_binary` (the extracted binary) -> replace. Use
         /// `verify_checksum`/`verifying_keys` to gate the download by content; use `verify_binary` to
-        /// gate it by running the new binary. A returned error's message becomes the reason of the
-        /// resulting `Error::VerificationRejected`.
+        /// gate it by running the new binary. Reject with
+        /// [`Error::verification_rejected("reason")`](crate::Error::verification_rejected), which is
+        /// surfaced as-is; any other returned error's message becomes the reason of the resulting
+        /// `Error::VerificationRejected`.
         pub fn verify_binary(
             &mut self,
             verify: impl Fn(&std::path::Path) -> crate::Result<()> + Send + Sync + 'static,

--- a/src/update.rs
+++ b/src/update.rs
@@ -301,7 +301,7 @@ impl Releases {
     /// Construct a `Releases` from a fetched (newest-first) release list with no associated current
     /// version, mirroring the bare-listing state the backends' `ReleaseList::fetch` returns.
     /// `current_version()` is `None` and `is_update_available()` errors with
-    /// [`Error::MissingField`], since there is nothing to compare against. Use
+    /// [`Error::NoCurrentVersion`], since there is nothing to compare against. Use
     /// [`from_releases`](Self::from_releases) when you have a current version to compare.
     pub fn from_listing(releases: Vec<Release>) -> Self {
         Self {
@@ -459,7 +459,7 @@ pub trait ReleaseSource: Send + Sync {
     /// "not compatible"). You therefore do **not** need to filter out the current or older versions
     /// (they are ignored) — but returning them is harmless, and returning the list newest-first
     /// ensures the right release is chosen.
-    fn get_latest_releases(&self) -> Result<Vec<Release>>;
+    fn get_releases(&self) -> Result<Vec<Release>>;
 
     /// Fetch the release for an explicit tag/version.
     fn get_release_version(&self, ver: &str) -> Result<Release>;
@@ -508,10 +508,8 @@ pub trait AsyncReleaseSource: Send + Sync {
     fn get_latest_release(&self) -> impl std::future::Future<Output = Result<Release>> + Send + '_;
 
     /// Fetch the candidate releases, **newest first**. See
-    /// [`ReleaseSource::get_latest_releases`] for how the updater treats the returned list.
-    fn get_latest_releases(
-        &self,
-    ) -> impl std::future::Future<Output = Result<Vec<Release>>> + Send + '_;
+    /// [`ReleaseSource::get_releases`] for how the updater treats the returned list.
+    fn get_releases(&self) -> impl std::future::Future<Output = Result<Vec<Release>>> + Send + '_;
 
     /// Fetch the release for an explicit tag/version.
     fn get_release_version<'a>(
@@ -594,8 +592,8 @@ pub trait AsyncReleaseUpdate: UpdateConfig + UpdateInternals {
 
 /// Implementation detail used to seal [`ReleaseUpdate`].
 ///
-/// Downstream code can *use* `ReleaseUpdate` (every backend's `build()` returns a
-/// `Box<dyn ReleaseUpdate>`) but cannot implement it for foreign types, which leaves the
+/// Downstream code can *use* `ReleaseUpdate` (every backend's `build()` returns a concrete
+/// `Update` implementing it) but cannot implement it for foreign types, which leaves the
 /// crate free to evolve the trait without a breaking change.
 pub(crate) mod sealed {
     pub trait Sealed {}
@@ -726,8 +724,9 @@ pub(crate) trait UpdateInternals: sealed::Sealed {
 ///
 /// This trait is **sealed** (via its [`UpdateConfig`] supertrait): it is implemented only by this
 /// crate's backend `Update` types and cannot be implemented for types outside the crate. You
-/// consume it as the return type of each backend's `build()` (`Box<dyn ReleaseUpdate>`) — call
-/// `update()` / `update_extended()` on it — but you do not implement it yourself.
+/// consume it through the concrete `Update` each backend's `build()` returns (whose inherent
+/// `update()` / `update_extended()` verbs forward here), or as a generic bound — but you do not
+/// implement it yourself.
 ///
 /// The shared accessor methods live on the [`UpdateConfig`] supertrait. They resolve on a
 /// `dyn ReleaseUpdate` without importing it, and in generic code bounded `R: ReleaseUpdate` they
@@ -1252,9 +1251,14 @@ fn install_binary(
 ) -> Result<()> {
     if let Some(verify) = verify {
         // A hook that returns `Err` (an explicit rejection or a hook IO error) aborts the install;
-        // its message becomes the rejection reason.
-        verify(new_exe).map_err(|e| Error::VerificationRejected {
-            reason: Some(e.to_string()),
+        // its message becomes the rejection reason. An error that already is a
+        // `VerificationRejected` (e.g. built via `Error::verification_rejected`) passes through
+        // unwrapped so the reason is not nested inside another rejection message.
+        verify(new_exe).map_err(|e| match e {
+            Error::VerificationRejected { .. } => e,
+            other => Error::VerificationRejected {
+                reason: Some(other.to_string()),
+            },
         })?;
     }
     let current_exe = std::env::current_exe()?;
@@ -1407,6 +1411,41 @@ mod tests {
         assert!(
             !releases.is_update_available().unwrap(),
             "no release exceeds 1.0.0 => no update available"
+        );
+    }
+
+    #[test]
+    fn releases_is_update_available_propagates_semver_error() {
+        // The doc contract: the first release *reached* whose version fails to parse as semver
+        // propagates its error (unlike `choose_latest_release`, which silently skips unparseable
+        // versions). Nothing before the bad entry is strictly newer, so the scan reaches it.
+        let releases = Releases::new(
+            vec![rel("0.9.0"), rel("not-a-version"), rel("2.0.0")],
+            "1.0.0".to_string(),
+        );
+        let err = releases
+            .is_update_available()
+            .expect_err("an unparseable version reached by the scan must error");
+        assert!(
+            matches!(err, crate::errors::Error::SemVer(_)),
+            "expected Error::SemVer, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn releases_is_update_available_short_circuits_before_semver_error() {
+        // The complement: a strictly-newer release positioned before the unparseable one
+        // short-circuits to Ok(true); the bad entry is never examined.
+        let releases = Releases::new(
+            vec![rel("2.0.0"), rel("not-a-version")],
+            "1.0.0".to_string(),
+        );
+        assert!(
+            releases
+                .is_update_available()
+                .expect("a found update wins over a later parse error"),
+            "2.0.0 > 1.0.0 must return true before reaching the bad entry"
         );
     }
 
@@ -1940,7 +1979,7 @@ mod tests {
         async fn get_latest_release(&self) -> Result<Release> {
             Release::builder().version("2.0.0").build()
         }
-        async fn get_latest_releases(&self) -> Result<Vec<Release>> {
+        async fn get_releases(&self) -> Result<Vec<Release>> {
             Ok(vec![Release::builder().version("2.0.0").build()?])
         }
         async fn get_release_version(&self, ver: &str) -> Result<Release> {
@@ -2024,7 +2063,7 @@ mod tests {
         fn get_latest_release(&self) -> Result<Release> {
             Release::builder().version("1.0.0").build()
         }
-        fn get_latest_releases(&self) -> Result<Vec<Release>> {
+        fn get_releases(&self) -> Result<Vec<Release>> {
             Ok(vec![Release::builder().version("1.0.0").build()?])
         }
         fn get_release_version(&self, v: &str) -> Result<Release> {
@@ -2081,6 +2120,34 @@ mod tests {
             "nothing is installed when verification fails"
         );
         assert!(new_exe.exists(), "the extracted binary is left untouched");
+    }
+
+    #[test]
+    fn install_binary_passes_verification_rejected_through_unwrapped() {
+        // A hook rejecting via `Error::verification_rejected` surfaces its reason verbatim: the
+        // already-`VerificationRejected` error passes through instead of being re-wrapped with the
+        // full Display string ("VerificationRejectedError: ...") nested inside the reason.
+        let dir = tempfile::tempdir().unwrap();
+        let new_exe = dir.path().join("new");
+        std::fs::write(&new_exe, b"new binary").unwrap();
+        let dest = dir.path().join("installed");
+
+        let reject: Box<DynVerifyFn> = Box::new(|_: &std::path::Path| {
+            Err(crate::errors::Error::verification_rejected("bad signature"))
+        });
+        let err = install_binary(&new_exe, &dest, Some(&*reject))
+            .expect_err("a rejecting verify hook must abort the install");
+        match err {
+            crate::errors::Error::VerificationRejected { reason } => {
+                assert_eq!(
+                    reason.as_deref(),
+                    Some("bad signature"),
+                    "the constructor's reason must pass through unwrapped"
+                );
+            }
+            other => panic!("expected Error::VerificationRejected, got {:?}", other),
+        }
+        assert!(!dest.exists());
     }
 
     #[test]

--- a/tests/error_helpers_external.rs
+++ b/tests/error_helpers_external.rs
@@ -5,8 +5,9 @@
 //!
 //! ## What is and is not testable here
 //!
-//! The three struct variants newly annotated `#[non_exhaustive]` — `Unauthorized`, `HttpStatus`,
-//! `InvalidAssetName` — **cannot be constructed from outside the crate**. Attempting:
+//! Every struct variant is annotated `#[non_exhaustive]` (`Unauthorized`, `HttpStatus`,
+//! `NotFound`, `ChecksumMismatch`, `InvalidAssetName`, …) and **cannot be constructed with a
+//! struct literal from outside the crate**. Attempting:
 //!
 //! ```ignore
 //! // compile error: cannot create non-exhaustive struct with explicit field values from outside
@@ -20,7 +21,9 @@
 //! observable behaviour (Display strings, helpers, source() return values).
 //!
 //! What IS testable here:
-//! - Variants that are constructable from outside: `NotFound`, `Io`, `Aborted`, `Config`, …
+//! - The public constructors (`Error::http_status_error`, `Error::no_release_found`,
+//!   `Error::verification_rejected`, …) build the variants a downstream crate needs to return.
+//! - Tuple variants that remain constructable from outside: `Io`, `Aborted`, …
 //! - The enum-level `#[non_exhaustive]` forces a wildcard in any downstream `match`.
 //! - Error propagation through an injected `HttpClient` (error path not covered elsewhere).
 
@@ -57,14 +60,14 @@ impl HttpClient for IoErrorClient {
 // Tests
 // ---------------------------------------------------------------------------
 
-// `Error::NotFound` is not `#[non_exhaustive]` on the variant, so it can be constructed
-// and exhaustively destructured from outside. This pins the external constructability contract
-// and verifies `http_status()` / `url()` / `source()` from an external-crate perspective.
+// `Error::NotFound` is `#[non_exhaustive]` on the variant, so a downstream crate builds it via
+// the `http_status_error` constructor (404 maps to `NotFound`). This pins the constructor
+// contract and verifies `http_status()` / `url()` / `source()` from an external-crate
+// perspective.
 #[test]
 fn not_found_constructable_and_helpers_correct_from_outside() {
-    let err = Error::NotFound {
-        url: "https://example.com/missing".to_string(),
-    };
+    let err = Error::http_status_error(404, "https://example.com/missing");
+    assert!(matches!(err, Error::NotFound { .. }));
     assert_eq!(err.http_status(), Some(404));
     assert_eq!(err.url(), Some("https://example.com/missing"));
     // NotFound is field-only: no chained source.
@@ -74,6 +77,18 @@ fn not_found_constructable_and_helpers_correct_from_outside() {
     );
     let shown = err.to_string();
     assert!(shown.starts_with("NotFoundError: "), "got: {shown}");
+}
+
+// `Error::verification_rejected` builds the rejection a `verify_binary` hook returns; the
+// `VerificationRejected` variant itself is `#[non_exhaustive]` and not literal-constructable.
+#[test]
+fn verification_rejected_constructable_from_outside() {
+    let err = Error::verification_rejected("bad signature");
+    assert!(matches!(err, Error::VerificationRejected { .. }));
+    let shown = err.to_string();
+    assert!(shown.contains("bad signature"), "got: {shown}");
+    assert_eq!(err.http_status(), None);
+    assert_eq!(err.url(), None);
 }
 
 // `Error::Io` wraps `std::io::Error` which itself implements `std::error::Error`.
@@ -110,7 +125,7 @@ fn error_enum_match_requires_wildcard_arm() {
         }
     }
 
-    assert_eq!(classify(&Error::NotFound { url: "u".into() }), "not-found");
+    assert_eq!(classify(&Error::http_status_error(404, "u")), "not-found");
     assert_eq!(classify(&Error::Aborted), "aborted");
     assert_eq!(
         classify(&Error::Io(std::io::Error::other("x"))),


### PR DESCRIPTION
API polish ahead of the 1.0.0 final, released as 1.0.0-rc.4.

Breaking vs rc.3 (folded into the 1.0 migration guides):
- Rename `ReleaseSource::get_latest_releases` / `AsyncReleaseSource::get_latest_releases` to `get_releases`: it returns the source's unfiltered candidate list, which the old name misstated. The updater's filtered `get_newer_releases` is unchanged.
- Mark `ChecksumMismatch` and `NotFound` `#[non_exhaustive]`, matching every other struct variant on `Error`. Struct patterns need `..`; construct a 404 via `Error::http_status_error(404, url)`.
- Map single-release-endpoint parse failures to `Error::InvalidResponse` (was `Error::Json`), matching the listing parsers, so one variant covers "unparseable backend response" on every path.

Additive:
- Add `Error::verification_rejected(reason)` for `verify_binary` hooks; the pipeline surfaces an already-`VerificationRejected` error as-is instead of re-wrapping it.
- Expose the `*_async` verbs as inherent methods on `backends::custom::AsyncUpdate<S>`, matching the built-in backends' `AsyncUpdate` types (no `AsyncReleaseUpdate` import needed).

Also:
- Remove dead auth threading in the github/gitlab pagination plans (auth is applied centrally by `RequestConfig::apply_auth`).
- Doc fixes: `from_listing` error variant, `build()` return type in the sealed-trait docs, ureq feature coexistence, and the migration-guide `match` examples that destructured `#[non_exhaustive]` variants without `..`.
- New tests: `Error::SemVer` propagation and short-circuit in `Releases::is_update_available`, `InvalidResponse` on single-release parse failures per backend, `verification_rejected` pass-through and external constructability.