### PR TITLE
final 1.0 api polish (rc.5)

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -68,8 +68,9 @@ Check for:
   any helper traits) expose a consistent method set with consistent signatures
   (`&self` vs `&mut self`)?
 - **Feature-gate symmetry** — is each public item gated behind exactly the features it
-  needs? Are the `reqwest`/`ureq` and `default-tls`/`rustls` selections handled
-  consistently, and is the mutual exclusion surfaced clearly?
+  needs? Are the `reqwest`/`ureq` and `native-tls`/`rustls` selections handled
+  consistently, and is the coexistence model (both clients / both TLS providers can be
+  enabled; reqwest and rustls win) surfaced clearly?
 - **Doc / CHANGELOG alignment** — do the `src/lib.rs` docs, the `[unreleased]` CHANGELOG
   section, and any migration notes accurately describe the shipped API (named types,
   signatures, builder/setter names, feature gates)?
@@ -148,10 +149,11 @@ cargo readme --no-indent-headings > README.md
 Build the full feature set on both http clients and run the tests:
 
 ```bash
-cargo test --features "archive-tar archive-zip compression-flate2 compression-zip-deflate compression-zip-bzip2 signatures s3-auth"
-cargo build --no-default-features --features "ureq default-tls archive-tar archive-zip compression-flate2 compression-zip-deflate compression-zip-bzip2 signatures s3-auth"
+cargo test --features "github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures checksums s3-auth"
+cargo build --no-default-features --features "ureq native-tls github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures checksums s3-auth"
 ```
 
+(`make ci` runs these lanes plus fmt/clippy/async and is preferred when time allows.)
 Fix any compilation errors before proceeding.
 
 ### 6. Commit or amend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [unreleased]
 
+### Added
+- `Error::checksum_mismatch(expected, computed)`: build the `ChecksumMismatch` variant, which
+  became `#[non_exhaustive]` in rc.4 and had no public construction path.
+- `Error::no_release_found_for_target(target)`: the asset-scoped sibling of `no_release_found()`
+  (see the constructor change below).
+- The `futures_util` and `bytes` crates are re-exported at the root under the `async` feature:
+  their types appear in the `AsyncHttpClient`/`AsyncHttpResponse` signatures (`BoxFuture`,
+  `BoxStream`, `Bytes`), so a custom async transport no longer needs them as direct dependencies.
+- docs.rs builds with the `ureq` feature, so `ureq_agent`, `UreqClient`, and the `ureq` re-export
+  now appear in the rendered API docs.
+
+### Changed
+- `Error::no_release_found(target: Option<String>)` is split into `no_release_found()` (no
+  argument) and `no_release_found_for_target(impl Into<String>)`. Migration:
+  `no_release_found(None)` -> `no_release_found()`; `no_release_found(Some(t))` ->
+  `no_release_found_for_target(t)`.
+- `Error::missing_asset_field` takes `impl Into<String>` (was `&'static str`) and the
+  `MissingAssetField` variant's `field` is a `String`, so a custom source can report a dynamic
+  field path (e.g. `format!("assets[{i}].url")`). Migration: construction sites are
+  source-compatible; a `field` binding from a pattern match is now a `&String`.
+
+### Fixed
+- `verify_signature`'s "Verifying downloaded file..." message respects `show_output(false)`; it
+  was printed unconditionally.
+- An s3 `Endpoint::Generic` URL without a trailing slash is normalized at URL-build time; it
+  previously produced malformed (and, under `s3-auth`, wrongly signed) download URLs by
+  concatenating the key directly onto the endpoint.
+- The github backend percent-encodes `repo_owner`/`repo_name` in API URLs, matching gitlab/gitea
+  (no wire change for valid github.com names).
+- A header-build failure while following a github/gitlab pagination `Link` propagates as an error
+  instead of panicking (matching gitea).
+- Doc fixes: the `github`/`gitea` example run commands referenced the removed
+  `compression-flate2` feature (and gitea's omitted its required `gitea` feature); the github
+  example's Enterprise comment used the renamed-away `.url(...)` setter; both migration guides
+  claimed MSRV 1.85 (it is 1.88) and that `is_update_available_async()` was removed (it ships);
+  the rc.2 changelog entry claimed default-feature builds compile on 1.85.
+
 ## [1.0.0-rc.4]
 API polish from a pre-1.0 consumer-experience review: three breaking changes (all folded into the
 [1.0 migration guide](docs/migrations/0.x-to-1.0-human.md)) plus additive constructors, inherent
@@ -136,8 +173,8 @@ edition 2024 and raises the MSRV to 1.88 (the `zip` 8 dependency requires it).
   retry backoff (default 100ms base, ~3.2s cap).
 
 ### Changed
-- Edition 2024. MSRV raised from 1.85 to 1.88 (required by the `zip` 8 dependency, pulled by the
-  `archive-zip` and `signatures` features; default-feature builds still compile on 1.85).
+- Edition 2024. MSRV raised from 1.85 to 1.88 (required by the `zip` 8 dependency and by
+  1.88 language features used unconditionally in the crate).
 - Default features changed from `["reqwest", "default-tls"]` to
   `["reqwest", "rustls", "progress-bar", "github", "archive-tar", "compression-tar-gz"]`: default
   TLS is now `rustls`, only the `github` backend is on by default (gitlab/gitea/s3 opt-in), and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+## [1.0.0-rc.5]
+Final polish from a full-surface review of rc.4: two breaking `Error`-constructor changes (folded
+into the [1.0 migration guide](docs/migrations/0.x-to-1.0-human.md)), additive constructors and
+re-exports, and fixes for an s3 url bug, an ungated verify message, and stale docs.
+
 ### Added
 - `Error::checksum_mismatch(expected, computed)`: build the `ChecksumMismatch` variant, which
   became `#[non_exhaustive]` in rc.4 and had no public construction path.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.88"
 [package.metadata.docs.rs]
 features = [
   "reqwest",
+  "ureq",
   "native-tls",
   "archive-zip",
   "compression-zip-bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self_update"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 description = "Self updates for standalone executables"
 repository = "https://github.com/jaemk/self_update"
 keywords = ["update", "upgrade", "download", "release"]

--- a/docs/migrations/0.x-to-1.0-human.md
+++ b/docs/migrations/0.x-to-1.0-human.md
@@ -292,8 +292,8 @@ the public `ReleaseSource` (or `AsyncReleaseSource`) trait instead and drive it 
 
 ## 5. Features and the build baseline
 
-The crate is now edition 2024 (MSRV unchanged at `1.85`). Several feature-level changes affect your
-`Cargo.toml`.
+The crate is now edition 2024 and the MSRV is raised to `1.88` (from `1.85`). Several
+feature-level changes affect your `Cargo.toml`.
 
 **Two features were renamed:**
 
@@ -408,7 +408,7 @@ changed shape:
 - `get_release_version(tag)` (specific-tag lookup) is unchanged.
 - `is_update_available()` now returns `Result<Option<Release>>`: the newest strictly-newer
   release, or `None` when up to date (was a `bool` that fetched the release list a second time).
-  `is_update_available_async()` is removed; see the async pre-check below.
+  `is_update_available_async()` has the same new shape on the async updaters.
 
 `Releases` (re-exported as `self_update::Releases`) holds the fetched releases plus your current
 version. It has `all() -> &[Release]`, `latest() -> Option<&Release>` (newest first),
@@ -552,8 +552,10 @@ a sealed mirror of `ReleaseUpdate` for the async verbs, usable as a bound.
 
 **Error constructors for source impls.** The release-flow `Error` variants are
 `#[non_exhaustive]`, so a downstream source cannot build them as struct literals. Use the public
-constructors instead: `Error::no_release_found(target)`, `Error::missing_asset_field(field)`,
-`Error::invalid_response(source)`, and `Error::http_status_error(status, url)`.
+constructors instead: `Error::no_release_found()` (or `Error::no_release_found_for_target(target)`
+when an asset-scoped lookup failed), `Error::missing_asset_field(field)` (any `Into<String>`,
+so dynamic paths like `format!("assets[{i}].url")` work), `Error::invalid_response(source)`,
+`Error::http_status_error(status, url)`, and `Error::checksum_mismatch(expected, computed)`.
 
 **Accessors moved to a `UpdateConfig` supertrait.** The many getter methods on `ReleaseUpdate`
 (`bin_name`, `current_version`, `target`, ...) now live on a new supertrait

--- a/docs/migrations/0.x-to-1.0.md
+++ b/docs/migrations/0.x-to-1.0.md
@@ -17,7 +17,7 @@ After applying, run the **Verify** step and resolve any remaining compiler error
 
 - File: `Cargo.toml`
 - Mechanical: set the `self_update` dependency version requirement to `"1.0"` (or `"1"`).
-- The crate is now edition 2024. The MSRV is unchanged (`1.85`).
+- The crate is now edition 2024. The MSRV is raised to `1.88` (was `1.85`).
 
 ## 1. Builder setter renames (mechanical, method-call level)
 
@@ -291,8 +291,8 @@ shape:
   a second time). Error: `mismatched types: expected bool, found Option<Release>`.
 - Under the `async` feature, the built updater adds `get_latest_release_async()` and
   `get_newer_releases_async()` returning `Result<Releases>`, and `get_release_version_async()`
-  returning `Result<Release>`. `is_update_available_async()` is removed; the async pre-check is
-  `get_latest_release_async().await?.is_update_available()?` (on `Releases`).
+  returning `Result<Release>`. `is_update_available_async()` exists with the same new shape as
+  the sync verb: `Result<Option<Release>>`.
 
 `build()` returns the concrete backend `Update` struct (was `Box<dyn ReleaseUpdate>`). The update
 verbs (`update`, `update_extended`, `get_latest_release`, `get_newer_releases`,
@@ -631,9 +631,10 @@ NOTE: this is a different method from the updater/`ReleaseUpdate` filtered fetch
 the updater method returns the strictly-newer subset.
 
 A source builds the `#[non_exhaustive]` release-flow error variants via the public constructors
-`Error::no_release_found(target)`, `Error::missing_asset_field(field)`,
-`Error::invalid_response(source)`, and `Error::http_status_error(status, url)` (struct-literal
-construction fails downstream).
+`Error::no_release_found()` / `Error::no_release_found_for_target(target)`,
+`Error::missing_asset_field(field)` (takes `impl Into<String>`),
+`Error::invalid_response(source)`, `Error::http_status_error(status, url)`, and
+`Error::checksum_mismatch(expected, computed)` (struct-literal construction fails downstream).
 
 **9c. `ReleaseUpdate` accessors moved to a `UpdateConfig` supertrait.** The shared accessor methods
 (`bin_name`, `current_version`, `target`, `release_tag`, `asset_identifier`, `auth_token`,
@@ -702,7 +703,7 @@ A successful build with no `self_update`-related errors means the migration is c
 | `no method named `uptodate`` on a `VersionStatus`/`ReleaseStatus` | §2a (now `is_up_to_date`) |
 | `no method named `updated`` on a `VersionStatus`/`ReleaseStatus` | §2a (now `is_updated`) |
 | `mismatched types: expected bool, found Option<Release>` near `is_update_available` | §3a (now returns `Result<Option<Release>>`; test with `.is_some()`) |
-| `no method named `is_update_available_async`` on an updater | §3a (removed; use `get_latest_release_async().await?.is_update_available()`) |
+| `mismatched types: expected bool, found Option<Release>` near `is_update_available_async` | §3a (same new shape as the sync verb: `Result<Option<Release>>`) |
 | `no method named `get_latest_releases`` on an updater / concrete `Update` | §3a (renamed `get_newer_releases`; the `ReleaseSource` method is separately renamed `get_releases`, §9b) |
 | `mismatched types: expected `Release`/`Vec<Release>`, found `Releases`` near `get_latest_release`/`get_newer_releases`/`fetch` | §3a (now return `Releases`; use `.latest()` / `.all()` / `.into_vec()`) |
 | `mismatched types: expected ... Box<dyn ReleaseUpdate>` at `build()` | §3a (`build()` returns the concrete `Update`; drop or update the annotation) |

--- a/examples/gitea.rs
+++ b/examples/gitea.rs
@@ -1,7 +1,7 @@
 /*!
 Example updating an executable to the latest version released via Gitea
 
-`cargo run --example gitea --features "archive-tar archive-zip compression-flate2 compression-zip-deflate"`
+`cargo run --example gitea --features "gitea archive-tar archive-zip compression-tar-gz compression-zip-deflate"`
 
 Unlike GitHub/GitLab, Gitea has no canonical public host, so the instance URL is required,
 set it with `.host(..)`.

--- a/examples/github.rs
+++ b/examples/github.rs
@@ -1,7 +1,7 @@
 /*!
 Example updating an executable to the latest version released via GitHub
 
-`cargo run --example github --features "archive-tar archive-zip compression-flate2 compression-zip-deflate"`.
+`cargo run --example github --features "archive-tar archive-zip compression-tar-gz compression-zip-deflate"`.
 
 Include `signatures` in the features list to enable zipsign verification
 */
@@ -38,7 +38,7 @@ fn run() -> Result<(), Box<dyn ::std::error::Error>> {
         //.no_confirm(true)
         //
         // For a GitHub Enterprise install, point at your API endpoint:
-        //.url("https://github.mycorp.com/api/v3")
+        //.api_base_url("https://github.mycorp.com/api/v3")
         //
         // For private repos, you will need to provide a GitHub auth token
         // **Make sure not to bake the token into your app**; it is recommended

--- a/specs/ref-errors.md
+++ b/specs/ref-errors.md
@@ -16,26 +16,28 @@ pipeline, and the checksum module.
 `Error` is declared `#[derive(Debug)] #[non_exhaustive] pub enum` at `errors.rs`. Every variant,
 what produces it, and its feature gate:
 
-Struct-form variants added after 1.0 are marked `#[non_exhaustive]` (in addition to the
-enum-level `#[non_exhaustive]`) so fields can be added without a breaking change. Variants
-considered shape-final (`NotFound`, `ChecksumMismatch`) are not.
+Every struct-form variant is marked `#[non_exhaustive]` (in addition to the enum-level
+`#[non_exhaustive]`) so fields can be added without a breaking change. This includes
+`NotFound` and `ChecksumMismatch` (aligned with their siblings in 1.0.0-rc.4); downstream
+code builds them via the public constructors (`http_status_error(404, ..)`,
+`checksum_mismatch(..)`).
 
 | Variant | Produced by | Feature gate | Opaque/boxed? |
 | --- | --- | --- | --- |
 | `Internal { message: String, source: Option<Box<dyn Error + Send + Sync>> }` | Genuine internal invariants / task failures: extractor source has no file name (`lib.rs`), path not in archive, non-UTF-8 archive path (`lib.rs`), and blocking-task join failure (`custom.rs`, `update.rs`). The join sites carry the tokio `JoinError` as `source`; the invariant sites set `source: None`. `#[non_exhaustive]`. | none | source boxed when present |
 | `VerificationRejected { reason: Option<String> }` | The post-update `verify_binary` callback returned `Err(..)`, so nothing was installed (`update.rs`). `reason` carries `Some(<error message>)` from the callback's returned error. `#[non_exhaustive]`. | none | no (struct fields) |
-| `ChecksumMismatch { expected: String, computed: String }` | The downloaded artifact's digest did not match the configured `Checksum` (`checksum.rs`). Both fields are lowercase hex-encoded digests. | none (compiled unconditionally) | no (struct fields) |
+| `ChecksumMismatch { expected: String, computed: String }` | The downloaded artifact's digest did not match the configured `Checksum` (`checksum.rs`). Both fields are lowercase hex-encoded digests. `#[non_exhaustive]`. | none (compiled unconditionally) | no (struct fields) |
 | `Aborted` | The user declined the interactive confirmation prompt (`lib.rs` `confirm()`). | none | no (unit) |
-| `NotFound { url: String }` | A request completed and returned HTTP 404. Raised by both HTTP clients when the response status is 404. | none | no (struct fields) |
+| `NotFound { url: String }` | A request completed and returned HTTP 404. Raised by both HTTP clients when the response status is 404. `#[non_exhaustive]`. | none | no (struct fields) |
 | `Unauthorized { status: u16, url: String }` | A request completed and returned HTTP 401 or 403. `status` holds the exact code. Raised by both HTTP clients. `#[non_exhaustive]`. | none | no (struct fields) |
 | `HttpStatus { status: u16, url: String }` | A request completed and returned any other non-2xx status (e.g. 500, 503). Raised by both HTTP clients. `#[non_exhaustive]`. | none | no (struct fields) |
 | `NoReleaseFound { target: Option<String> }` | The clean negative of a release lookup: no release / no matching release for a tag/version (`github.rs`, `gitlab.rs`, `gitea.rs`, `s3.rs`), or the resolved release had no asset for the requested target (`update.rs`, with `target: Some(...)`). `#[non_exhaustive]`. | none | no (struct fields) |
-| `MissingAssetField { field: &'static str }` | A release/asset payload was missing a required field (`url`/`name`/`tag_name`/`created_at`/`assets`/`browser_download_url`/`assets.links`) in each backend's `from_value` (`github.rs`, `gitlab.rs`, `gitea.rs`). `#[non_exhaustive]`. | none | no (struct fields) |
+| `MissingAssetField { field: String }` | A release/asset payload was missing a required field (`url`/`name`/`tag_name`/`created_at`/`assets`/`browser_download_url`/`assets.links`) in each backend's DTO conversion (`github.rs`, `gitlab.rs`, `gitea.rs`). `String` so a custom source can report a dynamic field path (e.g. `assets[2].url`). `#[non_exhaustive]`. | none | no (struct fields) |
 | `InvalidResponse { source: Box<dyn Error + Send + Sync> }` | A backend response could not be parsed: a malformed (non-array) JSON release-listing body (`github.rs`, `gitlab.rs`, `gitea.rs`), the S3 listing regex build failure, and the S3 XML parse failure (`s3.rs`). The underlying error is carried as `source`. `#[non_exhaustive]`. | none | yes (boxed source) |
 | `MissingField { field: &'static str }` | A required builder/configuration field was not set: `current_version`/`bin_name`/`bin_path_in_archive` (`common.rs`), `version` (`update.rs`), `source` (`custom.rs`), `repo_owner`/`repo_name` (`github.rs`, `gitlab.rs`, `gitea.rs`), `host` (`gitea.rs`), `bucket_name`/`region` (`s3.rs`). `#[non_exhaustive]`. | none | no (struct fields) |
 | `InvalidHeader { source: Box<dyn Error + Send + Sync> }` | A request header (`request_header` on the builders or on `Download`) was not a valid HTTP header. The setters are infallible; the error is deferred and surfaced from `build()` (via `common.rs`) or from `Download::download_to` / `download_to_async` (`lib.rs`). The source is a crate-internal `MessageError` carrying the validation message. `#[non_exhaustive]`. | none | yes (boxed source) |
 | `InvalidAuthToken { source: Box<dyn Error + Send + Sync> }` | An auth token could not be encoded as an HTTP `Authorization` header value (`github.rs`, `gitlab.rs`, `gitea.rs`, `update.rs`). The underlying header-value parse error is carried as `source`. `#[non_exhaustive]`. | none | yes (boxed source) |
-| `InvalidCertificate { source: Box<dyn Error + Send + Sync> }` | A custom TLS root certificate could not be parsed, or the HTTP client that would trust it could not be built. Produced by `RequestConfig::check()` (`common.rs`, surfaced from `build()`) and by `Download::download_to` / `download_to_async` (`lib.rs`) when `add_root_certificate` certs are supplied. `#[non_exhaustive]`. | none | yes (boxed source) |
+| `InvalidCertificate { source: Box<dyn Error + Send + Sync> }` | A custom TLS root certificate could not be parsed, or the HTTP client that would trust it could not be built. Produced by `RequestConfig::check()` (`common.rs`, surfaced from `build()`) and by `Download::download_to` / `download_to_async` (`lib.rs`) when `add_root_certificate` certs are supplied. Exception: on a ureq-only build a malformed **DER** certificate is not caught at `build()` (ureq's `from_der` is infallible) and surfaces as `Transport` at connection time; PEM is validated at `build()` on both clients. `#[non_exhaustive]`. | none | yes (boxed source) |
 | `InvalidProgressStyle { source: Box<dyn Error + Send + Sync> }` | A progress-bar template string was not valid; wraps the underlying `indicatif` template error (`lib.rs`). `#[non_exhaustive]`. | `progress-bar` | yes (boxed source) |
 | `Io(std::io::Error)` | Wraps a `std::io::Error`. Constructed directly and via `From<std::io::Error>`. | none | no (concrete `std::io::Error`) |
 | `Json(Box<dyn Error + Send + Sync>)` | `serde_json` failure, only via `From<serde_json::Error>`. | none | yes (boxed) |
@@ -220,11 +222,12 @@ type directly, since `std::io::Error` is stable std.)
 - `pub fn url(&self) -> Option<&str>` inherent method on `Error`.
 - Public constructors for custom `ReleaseSource` implementors (the release-flow variants are
   `#[non_exhaustive]`, so downstream code cannot build them with a struct literal):
-  `Error::no_release_found(target: Option<String>)`,
-  `Error::missing_asset_field(field: &'static str)`,
-  `Error::invalid_response(source: impl Into<Box<dyn Error + Send + Sync>>)`, and
+  `Error::no_release_found()` and `Error::no_release_found_for_target(target: impl Into<String>)`,
+  `Error::missing_asset_field(field: impl Into<String>)`,
+  `Error::invalid_response(source: impl Into<Box<dyn Error + Send + Sync>>)`,
   `Error::http_status_error(status: u16, url: impl Into<String>)` (routes through
-  `status_to_error`, so 404 -> `NotFound` and 401/403 -> `Unauthorized`).
+  `status_to_error`, so 404 -> `NotFound` and 401/403 -> `Unauthorized`), and
+  `Error::checksum_mismatch(expected: impl Into<String>, computed: impl Into<String>)`.
 - Trait impls: `Debug` (derived), `Display`, `std::error::Error` (with `source()`).
 - `From` impls: `std::io::Error`, `serde_json::Error`, `semver::Error` (always); `reqwest::Error`
   (`reqwest`), `ureq::Error` (`ureq`), `ZipError` (`archive-zip`), `ZipsignError` (`signatures`);
@@ -259,11 +262,10 @@ type directly, since `std::io::Error` is stable std.)
 - A checksum digest mismatch produces `Error::ChecksumMismatch { expected, computed }`. Both
   fields are lowercase hex-encoded digests.
 - A user-declined confirmation prompt produces `Error::Aborted`.
-- The struct-form variants carry `#[non_exhaustive]` on the variant (`Unauthorized`, `HttpStatus`,
-  `Internal`, `VerificationRejected`, `NoReleaseFound`, `MissingAssetField`, `InvalidResponse`,
-  `MissingField`, `InvalidHeader`, `InvalidAuthToken`, `InvalidCertificate`,
-  `InvalidProgressStyle`, `InvalidAssetName`); shape-final variants (`NotFound`,
-  `ChecksumMismatch`) are not.
+- Every struct-form variant carries `#[non_exhaustive]` on the variant (`Unauthorized`,
+  `HttpStatus`, `Internal`, `VerificationRejected`, `NoReleaseFound`, `MissingAssetField`,
+  `InvalidResponse`, `MissingField`, `InvalidHeader`, `InvalidAuthToken`, `InvalidCertificate`,
+  `InvalidProgressStyle`, `InvalidAssetName`, `NotFound`, `ChecksumMismatch`).
 - `Error::Internal` is reserved for genuine internal/invariant failures: extractor invariants,
   archive-path failures, and tokio blocking-task join failures (which carry the `JoinError` as
   `source`).
@@ -282,8 +284,8 @@ type directly, since `std::io::Error` is stable std.)
   `Error::InvalidAssetName { name }` before any file is created.
 - `ChecksumMismatch` is compiled unconditionally (no feature gate).
 - Custom sources build the release-flow variants through the public constructors
-  (`no_release_found`, `missing_asset_field`, `invalid_response`, `http_status_error`), not
-  struct literals.
+  (`no_release_found` / `no_release_found_for_target`, `missing_asset_field`,
+  `invalid_response`, `http_status_error`, `checksum_mismatch`), not struct literals.
 - The signatures-gated unit variant is named `SignatureNonUTF8`; its Display is
   `"SignatureError: cannot verify signature of a file with a non-UTF-8 name"`.
 - `ArchiveNotEnabled` Display starts with `"ArchiveNotEnabledError: "`.

--- a/specs/ref-version-and-target.md
+++ b/specs/ref-version-and-target.md
@@ -83,19 +83,19 @@ Asset selection happens in `resolve_and_confirm` (`src/update.rs:716-722`):
   `Option<ReleaseAsset>` result is used directly; the built-in `target`/`identifier`
   matching is bypassed entirely (`src/update.rs:718-719`).
 - Otherwise `release.asset_for(target, asset_identifier())` runs the default matcher.
-- Either way, `None` becomes `Error::Release` ("No asset found for target: ...")
-  (`src/update.rs:722`).
+- Either way, `None` becomes `Error::NoReleaseFound { target: Some(..) }`
+  (`resolve_and_confirm`, `src/update.rs`).
 
-Default matcher `Release::asset_for` (`src/update.rs:86-114`) is substring-based and
+Default matcher `Release::asset_for` (`src/update.rs`) is substring-based and
 tries three passes in order, returning the **first** matching asset (cloned):
 
-1. First asset whose `name` contains `target` and (if set) `identifier`
-   (`src/update.rs:90-97`).
-2. Else first asset whose `name` contains both `OS` and `ARCH`
-   (`std::env::consts::OS` / `ARCH`, `src/update.rs:3`) and (if set) `identifier`
-   (`src/update.rs:99-108`).
+1. First asset whose `name` contains `target` and (if set) `identifier`.
+2. Else first asset whose `name` contains both the arch and os tokens derived from the
+   configured `target` string by `target_arch_os(target)` (`src/update.rs`) - not the
+   build host's `std::env::consts` values, so an explicitly configured cross-target
+   selects its own assets - and (if set) `identifier`.
 3. Else, only if `identifier` is set, the first asset whose `name` contains
-   `identifier` (`src/update.rs:110-112`).
+   `identifier`.
 
 `identifier` (set via `asset_identifier(...)`, `src/macros.rs:266`) disambiguates when
 multiple assets match the same target; if unset, the first target match wins.

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -1,9 +1,10 @@
 /*!
 Configuration shared by every backend's `Update` builder.
 
-Each backend (`github`, `gitlab`, `gitea`, `s3`) layers a small amount of
-backend-specific configuration (repo coordinates, host/url, bucket, credentials) on top of
-an identical set of common update options (target, bin name, version, progress style, …).
+Each backend (`github`, `gitlab`, `gitea`, `s3`, `custom`) layers a small amount of
+backend-specific configuration (repo coordinates, host/url, bucket, credentials, a release
+source) on top of an identical set of common update options (target, bin name, version,
+progress style, …).
 
 [`CommonBuilderConfig`] holds those common options while a backend builder is being
 configured; [`CommonBuilderConfig::build`] validates them and produces a resolved
@@ -457,7 +458,6 @@ impl CommonBuilderConfig {
             progress_template: self.progress_template.clone(),
             #[cfg(feature = "progress-bar")]
             progress_chars: self.progress_chars.clone(),
-            auth_token: self.auth_token.clone(),
             progress_callback: self.progress_callback.clone(),
             verify: self.verify.clone(),
             asset_matcher: self.asset_matcher.clone(),
@@ -487,7 +487,6 @@ pub(crate) struct CommonConfig {
     pub progress_template: String,
     #[cfg(feature = "progress-bar")]
     pub progress_chars: String,
-    pub auth_token: Option<String>,
     pub progress_callback: Option<crate::ProgressCallback>,
     pub verify: Option<crate::VerifyCallback>,
     pub asset_matcher: Option<crate::AssetMatcher>,

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -294,7 +294,7 @@ impl<S: crate::update::AsyncReleaseSource> AsyncUpdateBuilder<S> {
     /// Confirm config and create a ready-to-use [`AsyncUpdate`].
     ///
     /// * Errors:
-    ///     * Config - no `source` was set, or an invalid `Update` configuration
+    ///     * `MissingField` - no `source` was set, or an invalid `Update` configuration
     pub fn build_async(&self) -> Result<AsyncUpdate<S>> {
         let source = self
             .source

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -22,12 +22,12 @@ struct AssetDto {
 
 impl AssetDto {
     fn into_asset(self) -> Result<ReleaseAsset> {
-        let download_url = self.browser_download_url.ok_or(Error::MissingAssetField {
-            field: "browser_download_url",
-        })?;
+        let download_url = self
+            .browser_download_url
+            .ok_or_else(|| Error::missing_asset_field("browser_download_url"))?;
         let name = self
             .name
-            .ok_or(Error::MissingAssetField { field: "name" })?;
+            .ok_or_else(|| Error::missing_asset_field("name"))?;
         Ok(ReleaseAsset::new(name, download_url))
     }
 }
@@ -47,13 +47,13 @@ impl ReleaseDto {
     fn into_release(self) -> Result<Release> {
         let tag = self
             .tag_name
-            .ok_or(Error::MissingAssetField { field: "tag_name" })?;
-        let date = self.created_at.ok_or(Error::MissingAssetField {
-            field: "created_at",
-        })?;
+            .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
+        let date = self
+            .created_at
+            .ok_or_else(|| Error::missing_asset_field("created_at"))?;
         let assets = self
             .assets
-            .ok_or(Error::MissingAssetField { field: "assets" })?;
+            .ok_or_else(|| Error::missing_asset_field("assets"))?;
         let name = self.name.unwrap_or_else(|| tag.clone());
         let assets = assets
             .into_iter()

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -23,10 +23,10 @@ struct AssetDto {
 
 impl AssetDto {
     fn into_asset(self) -> Result<ReleaseAsset> {
-        let download_url = self.url.ok_or(Error::MissingAssetField { field: "url" })?;
+        let download_url = self.url.ok_or_else(|| Error::missing_asset_field("url"))?;
         let name = self
             .name
-            .ok_or(Error::MissingAssetField { field: "name" })?;
+            .ok_or_else(|| Error::missing_asset_field("name"))?;
         Ok(ReleaseAsset::new(name, download_url))
     }
 }
@@ -46,13 +46,13 @@ impl ReleaseDto {
     fn into_release(self) -> Result<Release> {
         let tag = self
             .tag_name
-            .ok_or(Error::MissingAssetField { field: "tag_name" })?;
-        let date = self.created_at.ok_or(Error::MissingAssetField {
-            field: "created_at",
-        })?;
+            .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
+        let date = self
+            .created_at
+            .ok_or_else(|| Error::missing_asset_field("created_at"))?;
         let assets = self
             .assets
-            .ok_or(Error::MissingAssetField { field: "assets" })?;
+            .ok_or_else(|| Error::missing_asset_field("assets"))?;
         let name = self.name.unwrap_or_else(|| tag.clone());
         let assets = assets
             .into_iter()
@@ -197,8 +197,8 @@ impl ReleaseList {
             self.custom_url
                 .as_ref()
                 .unwrap_or(&"https://api.github.com".to_string()),
-            self.repo_owner,
-            self.repo_name
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
         let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
@@ -220,8 +220,8 @@ impl ReleaseList {
             self.custom_url
                 .as_ref()
                 .unwrap_or(&"https://api.github.com".to_string()),
-            self.repo_owner,
-            self.repo_name
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
         let releases =
@@ -363,8 +363,8 @@ impl Update {
         format!(
             "{}/repos/{}/{}/releases",
             self.api_base(),
-            self.repo_owner,
-            self.repo_name
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         )
     }
 
@@ -373,8 +373,8 @@ impl Update {
         format!(
             "{}/repos/{}/{}/releases/latest",
             self.api_base(),
-            self.repo_owner,
-            self.repo_name
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name)
         )
     }
 
@@ -383,8 +383,8 @@ impl Update {
         format!(
             "{}/repos/{}/{}/releases/tags/{}",
             self.api_base(),
-            self.repo_owner,
-            self.repo_name,
+            urlencoding::encode(&self.repo_owner),
+            urlencoding::encode(&self.repo_name),
             urlencoding::encode(ver)
         )
     }
@@ -488,7 +488,14 @@ fn release_array_page(
                 items.push(release);
             }
             let next = next_link(resp_headers)
-                .map(|next_url| release_array_page(next_url, api_headers_for(), stop_at.clone()));
+                .map(|next_url| -> Result<PageRequest<Release>> {
+                    Ok(release_array_page(
+                        next_url,
+                        api_headers()?,
+                        stop_at.clone(),
+                    ))
+                })
+                .transpose()?;
             Ok(Page {
                 items,
                 next,
@@ -514,14 +521,6 @@ fn single_plan(url: String) -> Result<PageRequest<Release>> {
             Ok(Page::last(vec![dto.into_release()?]))
         }),
     })
-}
-
-/// Build the github request headers for a continuation page. Used when rebuilding a next-page
-/// request inside the parser closure, where returning a `Result` is not possible. Panics only on
-/// an internal user-agent bug (the header value is a static string that is always valid); a
-/// silent `.unwrap_or_default()` would drop the User-Agent on that failure path.
-fn api_headers_for() -> HeaderMap {
-    api_headers().expect("api_headers builds from static values")
 }
 
 #[cfg(feature = "async")]
@@ -1398,6 +1397,37 @@ mod tests {
     }
 
     #[test]
+    fn urls_percent_encode_repo_owner_and_name() {
+        // `releases_url()`/`latest_url()`/`tag_url()` percent-encode `repo_owner` and
+        // `repo_name`, matching the gitlab/gitea backends. github.com restricts these to
+        // URL-safe characters, but a GitHub Enterprise namespace (or a copy-paste of this URL
+        // construction) must not smuggle raw URL-special characters into the path.
+        let (base, captured) = stub_capturing(|_| {
+            vec![Resp {
+                status: "200 OK",
+                link: None,
+                body: release_obj_json("v1.0.0"),
+            }]
+        });
+        let upd = super::Update::configure()
+            .repo_owner("own er")
+            .repo_name("re#po")
+            .bin_name("app")
+            .current_version("0.1.0")
+            .api_base_url(&base)
+            .build()
+            .unwrap();
+        let _ = upd.get_release_version("v1.0.0").unwrap();
+        let request = &captured.lock().unwrap()[0];
+        let request_line = request.lines().next().unwrap_or_default();
+        assert!(
+            request_line.contains("/repos/own%20er/re%23po/releases/tags/"),
+            "owner and name must be percent-encoded in the request path, got: {}",
+            request_line
+        );
+    }
+
+    #[test]
     fn builder_stores_timeout_and_request_header() {
         use std::time::Duration;
         let upd = super::Update::configure()
@@ -2187,25 +2217,6 @@ mod tests {
                 .get(crate::http_client::header::AUTHORIZATION)
                 .is_none(),
             "api_headers() must not set an Authorization header"
-        );
-    }
-
-    #[test]
-    fn api_headers_for_takes_no_param_and_sets_user_agent() {
-        // I1+I2: api_headers_for() is now a zero-arg function that uses .expect instead of
-        // .unwrap_or_default, so a failure surfaces rather than silently producing empty headers.
-        // This test calls it with no arguments -- it would fail to compile against the old
-        // `api_headers_for(auth: &Option<String>)` signature. The User-Agent assertion proves
-        // headers are not silently empty (as .unwrap_or_default() would give on a failure path).
-        let headers = super::api_headers_for();
-        assert_eq!(
-            headers
-                .get(crate::http_client::header::USER_AGENT)
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            "rust/self-update",
-            "api_headers_for() must return headers with the rust/self-update User-Agent set"
         );
     }
 

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -23,10 +23,10 @@ struct AssetDto {
 
 impl AssetDto {
     fn into_asset(self) -> Result<ReleaseAsset> {
-        let download_url = self.url.ok_or(Error::MissingAssetField { field: "url" })?;
+        let download_url = self.url.ok_or_else(|| Error::missing_asset_field("url"))?;
         let name = self
             .name
-            .ok_or(Error::MissingAssetField { field: "name" })?;
+            .ok_or_else(|| Error::missing_asset_field("name"))?;
         Ok(ReleaseAsset::new(name, download_url))
     }
 }
@@ -54,13 +54,14 @@ impl ReleaseDto {
     fn into_release(self) -> Result<Release> {
         let tag = self
             .tag_name
-            .ok_or(Error::MissingAssetField { field: "tag_name" })?;
-        let date = self.created_at.ok_or(Error::MissingAssetField {
-            field: "created_at",
-        })?;
-        let links = self.assets.links.ok_or(Error::MissingAssetField {
-            field: "assets.links",
-        })?;
+            .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
+        let date = self
+            .created_at
+            .ok_or_else(|| Error::missing_asset_field("created_at"))?;
+        let links = self
+            .assets
+            .links
+            .ok_or_else(|| Error::missing_asset_field("assets.links"))?;
         let name = self.name.unwrap_or_else(|| tag.clone());
         let assets = links
             .into_iter()
@@ -479,13 +480,15 @@ fn release_array_page(
                 }
                 items.push(release);
             }
-            let next = next_link(resp_headers).map(|next_url| {
-                release_array_page(
-                    next_url,
-                    api_headers().expect("api_headers builds from static values"),
-                    stop_at.clone(),
-                )
-            });
+            let next = next_link(resp_headers)
+                .map(|next_url| -> Result<PageRequest<Release>> {
+                    Ok(release_array_page(
+                        next_url,
+                        api_headers()?,
+                        stop_at.clone(),
+                    ))
+                })
+                .transpose()?;
             Ok(Page {
                 items,
                 next,

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1355,22 +1355,16 @@ fn build_s3_api_url(
             bucket_name, region_result?
         ),
         Endpoint::GCS => format!("https://storage.googleapis.com/{}/", bucket_name),
-        Endpoint::Generic(endpoint) => endpoint.clone(),
+        // Asset keys are appended directly to the base, so it must end with `/` like every
+        // crate-built base above; normalize a user-supplied endpoint that omits it.
+        Endpoint::Generic(endpoint) if endpoint.ends_with('/') => endpoint.clone(),
+        Endpoint::Generic(endpoint) => format!("{}/", endpoint),
     };
 
-    let api_url = match endpoint {
-        Endpoint::S3
-        | Endpoint::S3DualStack
-        | Endpoint::DigitalOceanSpaces
-        | Endpoint::Generic(..) => format!(
-            "{}?list-type=2&max-keys={}{}{}",
-            download_base_url, max_keys, prefix, continuation
-        ),
-        Endpoint::GCS => format!(
-            "{}?list-type=2&max-keys={}{}{}",
-            download_base_url, max_keys, prefix, continuation
-        ),
-    };
+    let api_url = format!(
+        "{}?list-type=2&max-keys={}{}{}",
+        download_base_url, max_keys, prefix, continuation
+    );
 
     #[cfg(feature = "s3-auth")]
     let api_url = auth::s3_signature_v4(&api_url, region, access_key, signature_ttl.as_secs())?;
@@ -3122,6 +3116,25 @@ mod tests {
         // consumed) and appends the v2 `list-type=2` listing query.
         let (base, url) = api_url(
             super::Endpoint::Generic("https://s3.example.com/bucket/".to_owned()),
+            "ignored-bucket",
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(base, "https://s3.example.com/bucket/");
+        assert_eq!(
+            url,
+            "https://s3.example.com/bucket/?list-type=2&max-keys=1000"
+        );
+    }
+
+    #[test]
+    fn build_s3_api_url_generic_normalizes_missing_trailing_slash() {
+        // Asset keys are appended directly to the download base (`format!("{base}{key}")`), so a
+        // Generic endpoint supplied without a trailing `/` must be normalized; otherwise every
+        // download URL is malformed (`...buckethey-1.0.0-linux`) and, under s3-auth, signed wrong.
+        let (base, url) = api_url(
+            super::Endpoint::Generic("https://s3.example.com/bucket".to_owned()),
             "ignored-bucket",
             None,
             None,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -101,11 +101,12 @@ pub enum Error {
     },
     /// A release or asset payload from the backend was missing a required field.
     ///
-    /// `field` is the name of the absent field (e.g. `"tag_name"`, `"browser_download_url"`).
+    /// `field` is the name of the absent field (e.g. `"tag_name"`, `"browser_download_url"`),
+    /// or a path to it (e.g. `"assets[2].url"`).
     #[non_exhaustive]
     MissingAssetField {
-        /// The name of the missing field in the release/asset payload.
-        field: &'static str,
+        /// The name of (or path to) the missing field in the release/asset payload.
+        field: String,
     },
     /// A backend response could not be parsed.
     ///
@@ -267,16 +268,38 @@ impl Error {
     // a struct literal. These constructors let a custom source return the canonical error for a
     // condition (no release, a malformed response, a bad status) instead of an opaque catch-all.
 
-    /// Construct a [`NoReleaseFound`](Error::NoReleaseFound) error. `target` is the requested target
-    /// triple when the lookup was asset-scoped, else `None`.
-    pub fn no_release_found(target: Option<String>) -> Error {
-        Error::NoReleaseFound { target }
+    /// Construct a [`NoReleaseFound`](Error::NoReleaseFound) error: the listing had no release, or
+    /// no release matched the requested tag/version. For a lookup that failed to find an asset for
+    /// a specific target triple, use
+    /// [`no_release_found_for_target`](Error::no_release_found_for_target).
+    pub fn no_release_found() -> Error {
+        Error::NoReleaseFound { target: None }
+    }
+
+    /// Construct a [`NoReleaseFound`](Error::NoReleaseFound) error for an asset-scoped lookup:
+    /// a release was resolved but had no asset matching `target`.
+    pub fn no_release_found_for_target(target: impl Into<String>) -> Error {
+        Error::NoReleaseFound {
+            target: Some(target.into()),
+        }
     }
 
     /// Construct a [`MissingAssetField`](Error::MissingAssetField) error for a release/asset payload
-    /// missing a required field.
-    pub fn missing_asset_field(field: &'static str) -> Error {
-        Error::MissingAssetField { field }
+    /// missing a required field. `field` names the absent field, or a path to it
+    /// (e.g. `format!("assets[{i}].url")`).
+    pub fn missing_asset_field(field: impl Into<String>) -> Error {
+        Error::MissingAssetField {
+            field: field.into(),
+        }
+    }
+
+    /// Construct a [`ChecksumMismatch`](Error::ChecksumMismatch) error from the expected and
+    /// computed digests (both hex-encoded lowercase).
+    pub fn checksum_mismatch(expected: impl Into<String>, computed: impl Into<String>) -> Error {
+        Error::ChecksumMismatch {
+            expected: expected.into(),
+            computed: computed.into(),
+        }
     }
 
     /// Construct an [`InvalidResponse`](Error::InvalidResponse) error wrapping the underlying parse
@@ -1221,7 +1244,7 @@ mod tests {
     // `MissingAssetField` Display names the absent payload field.
     #[test]
     fn missing_asset_field_display() {
-        let err = Error::MissingAssetField { field: "tag_name" };
+        let err = Error::missing_asset_field("tag_name");
         assert_eq!(
             err.to_string(),
             "ReleaseError: release/asset payload missing `tag_name`"
@@ -1562,7 +1585,7 @@ mod tests {
                 "VerificationRejectedError:",
             ),
             (Error::NoReleaseFound { target: None }, "ReleaseError:"),
-            (Error::MissingAssetField { field: "f" }, "ReleaseError:"),
+            (Error::missing_asset_field("f"), "ReleaseError:"),
             (
                 Error::InvalidResponse {
                     source: Box::new(MessageError("x".into())),

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -59,6 +59,10 @@ pub trait HttpResponse {
 
 /// Async sibling of [`HttpClient`] (reqwest + tokio only). Object-safe like the sync seam, so an
 /// async client can be injected as an `Arc<dyn AsyncHttpClient>`.
+///
+/// The signature types from foreign crates (`BoxFuture`, `BoxStream`, `Bytes`) are re-exported at
+/// the crate root (`self_update::futures_util`, `self_update::bytes`), so an implementation does
+/// not need them as direct dependencies.
 #[cfg(feature = "async")]
 pub trait AsyncHttpClient: Send + Sync {
     /// Issue a GET, returning a boxed future resolving to the status-checked response.

--- a/src/http_client/ureq.rs
+++ b/src/http_client/ureq.rs
@@ -260,6 +260,22 @@ mod tests {
     }
 
     #[test]
+    fn build_with_certs_accepts_garbage_der_deferring_validation() {
+        // ureq's `tls::Certificate::from_der` is infallible, so invalid DER bytes are accepted
+        // here and only surface at connection time. This is intentional and documented (on
+        // `add_root_certificate` and in the reference specs); the reqwest client rejects the same
+        // bytes at build time (`build_with_certs_rejects_garbage_der` in reqwest.rs). This test
+        // pins the asymmetry: if ureq ever gains eager DER validation, this fails and the
+        // deferred-validation caveat in the docs should be removed.
+        let res =
+            UreqClient::build_with_certs(&[crate::tls::Certificate::from_der(b"not der".to_vec())]);
+        assert!(
+            res.is_ok(),
+            "ureq DER validation is deferred to connection time; build must accept the bytes"
+        );
+    }
+
+    #[test]
     fn injected_agent_no_status_error_falls_through_to_is_success_check() {
         // 404 must still map to NotFound via the bottom-of-`get` is_success() path (not the
         // StatusCode arm, which never fires when http_status_as_error(false)).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,6 +462,16 @@ on the system OpenSSL cert layout.
 compile_error!("feature `async` requires the `reqwest` client - `ureq` has no async API");
 
 pub use http;
+// Re-export the crates whose types appear in the async transport-trait signatures
+// (`AsyncHttpClient` / `AsyncHttpResponse` name `BoxFuture`, `BoxStream`, and `Bytes`), so a
+// custom async transport can be implemented without adding `futures-util`/`bytes` as direct
+// dependencies (and without a version-skew risk against the ones this crate links).
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub use bytes;
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub use futures_util;
 // Re-export the selected HTTP client so callers can name the types accepted by the client-injection
 // setters (`reqwest_client` / `reqwest_async_client` / `ureq_agent`) without a separate dependency.
 #[cfg(feature = "reqwest")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -305,7 +305,9 @@ macro_rules! impl_update_config_accessors {
             &self.common.progress_chars
         }
         fn auth_token(&self) -> Option<&str> {
-            self.common.auth_token.as_deref()
+            // Single source of truth: the resolved token lives on the request config, where
+            // `apply_auth` reads it for both the listing and download paths.
+            self.common.request.auth_token.as_deref()
         }
         }
     };

--- a/src/update.rs
+++ b/src/update.rs
@@ -1000,7 +1000,12 @@ fn build_download<U: UpdateConfig + UpdateInternals + ?Sized>(
     // scheme/token is applied below by the shared `apply_auth` so the download honors a user
     // `request_header(AUTHORIZATION, ..)` override exactly like the listing path.
     let mut headers = u.api_headers(u.auth_token())?;
-    headers.insert(header::ACCEPT, "application/octet-stream".parse().unwrap());
+    headers.insert(
+        header::ACCEPT,
+        "application/octet-stream"
+            .parse()
+            .expect("application/octet-stream is a valid header value"),
+    );
     // Apply the backend's derived Authorization (scheme + token), skipped when the user supplied
     // their own Authorization via `request_header`. The token is attached only when the asset
     // download URL is on the configured API host (or an allow_auth_host entry), so a server-supplied
@@ -1128,7 +1133,12 @@ fn finish_update_owned(
     }
 
     #[cfg(feature = "signatures")]
-    verify_signature(tmp_archive_path, &ctx.verify_keys)?;
+    {
+        if !ctx.verify_keys.is_empty() {
+            println(show_output, "Verifying downloaded file...");
+        }
+        verify_signature(tmp_archive_path, &ctx.verify_keys)?;
+    }
 
     print_flush(show_output, "Extracting archive... ")?;
 
@@ -1305,8 +1315,6 @@ fn verify_signature(
     if keys.is_empty() {
         return Ok(());
     }
-
-    println!("Verifying downloaded file...");
 
     let archive_kind = crate::detect_archive(archive_path)?;
     #[cfg(any(feature = "archive-tar", feature = "archive-zip"))]

--- a/tests/error_helpers_external.rs
+++ b/tests/error_helpers_external.rs
@@ -91,6 +91,46 @@ fn verification_rejected_constructable_from_outside() {
     assert_eq!(err.url(), None);
 }
 
+// `Error::no_release_found` / `no_release_found_for_target` build the two shapes of
+// `NoReleaseFound` (which is `#[non_exhaustive]` and not literal-constructable) without the
+// caller spelling out an `Option`.
+#[test]
+fn no_release_found_constructors_from_outside() {
+    let plain = Error::no_release_found();
+    assert!(matches!(plain, Error::NoReleaseFound { .. }));
+
+    // `impl Into<String>`: a `&str` and a `format!` product both work.
+    let scoped = Error::no_release_found_for_target("x86_64-unknown-linux-gnu");
+    let shown = scoped.to_string();
+    assert!(shown.contains("x86_64-unknown-linux-gnu"), "got: {shown}");
+    let _ = Error::no_release_found_for_target(format!("{}-msvc", "x86_64"));
+}
+
+// `Error::missing_asset_field` accepts a dynamic field path, not just a `&'static str`.
+#[test]
+fn missing_asset_field_accepts_dynamic_paths_from_outside() {
+    let idx = 2;
+    let err = Error::missing_asset_field(format!("assets[{idx}].url"));
+    assert!(matches!(err, Error::MissingAssetField { .. }));
+    let shown = err.to_string();
+    assert!(shown.contains("assets[2].url"), "got: {shown}");
+}
+
+// `Error::checksum_mismatch` builds the `ChecksumMismatch` variant, which is
+// `#[non_exhaustive]` and otherwise unconstructable from outside the crate.
+#[test]
+fn checksum_mismatch_constructable_from_outside() {
+    let err = Error::checksum_mismatch("aa11", "bb22");
+    assert!(matches!(err, Error::ChecksumMismatch { .. }));
+    let shown = err.to_string();
+    assert!(
+        shown.contains("aa11") && shown.contains("bb22"),
+        "Display must carry both digests, got: {shown}"
+    );
+    assert_eq!(err.http_status(), None);
+    assert_eq!(err.url(), None);
+}
+
 // `Error::Io` wraps `std::io::Error` which itself implements `std::error::Error`.
 // The `source()` chain works end-to-end from outside the crate.
 #[test]


### PR DESCRIPTION
Last round of pre-1.0 fixes from a full-surface review of rc.4, released as 1.0.0-rc.5.

Breaking (vs rc.4):
- Split `Error::no_release_found(Option<String>)` into `no_release_found()` and `no_release_found_for_target(impl Into<String>)`
- `Error::missing_asset_field` takes `impl Into<String>` and the variant's `field` is a `String`, so dynamic field paths (`format!("assets[{i}].url")`) work

Added:
- `Error::checksum_mismatch(expected, computed)`: the variant became `#[non_exhaustive]` in rc.4 with no public construction path left
- `futures_util`/`bytes` re-exports under `async`: their types appear in the `AsyncHttpClient`/`AsyncHttpResponse` signatures, so a custom async transport needs no direct deps
- docs.rs builds with `ureq`, so `ureq_agent`/`UreqClient`/the `ureq` re-export render

Fixed:
- `verify_signature`'s "Verifying downloaded file..." now respects `show_output(false)`
- An s3 `Endpoint::Generic` url without a trailing slash produced malformed (and, under s3-auth, wrongly signed) download urls; normalized at url-build time
- github percent-encodes `repo_owner`/`repo_name` in api urls, matching gitlab/gitea
- A header-build failure on a github/gitlab pagination `Link` propagates instead of panicking (matching gitea); dropped the duplicate `CommonConfig.auth_token` field
- Stale docs: example run commands referenced the removed `compression-flate2` feature (gitea's also omitted its required `gitea` feature), the github example's `.url(...)` comment, migration guides claiming MSRV 1.85 and a removed `is_update_available_async`, spec drift in `ref-errors.md`/`ref-version-and-target.md`, the release skill's verify commands

New tests: s3 generic-endpoint slash normalization, github owner/name encoding, ureq deferred-DER-validation pin, external-crate constructor coverage.