### PR TITLE
1.0 api polish: `ReleaseSource` defaults, release validation, unified user-agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,16 +113,31 @@ cargo fmt --check      # verify only
 ```
 
 ## Lint
+The Makefile is the source of truth for the verification lanes; prefer `make check/clippy`
+(runs all three lanes) over the raw commands. If the raw commands below ever disagree with the
+Makefile's `REQWEST_FEATURES` / `UREQ_FEATURES` / `ASYNC_FEATURES`, trust the Makefile.
 ```bash
+# reqwest lane:
 cargo clippy --all-targets --features "github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
+# ureq lane:
 cargo clippy --all-targets --no-default-features --features "ureq native-tls github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
+# async lane (reqwest + async):
+cargo clippy --all-targets --features "async github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
 ```
 
 ## Test
-Tests are in-module (`#[cfg(test)] mod tests` in `src/…`, including the backend modules) plus doctests in `src/lib.rs` and the backend modules. No external services are required.
+Tests live in three places: in-module `#[cfg(test)] mod tests` blocks in `src/…` (including the
+backend modules), doctests in `src/lib.rs` and the backend modules, and integration tests in
+`tests/` (`custom_transport.rs`, `error_helpers_external.rs`) that exercise the crate through its
+public API. No external services are required. Prefer `make tests` (runs the default, reqwest,
+ureq, and async lanes); the raw commands are a fallback:
 ```bash
+# reqwest lane:
 cargo test --features "github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
+# ureq lane:
 cargo test --no-default-features --features "ureq native-tls github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
+# async lane (reqwest + async):
+cargo test --features "async github gitlab gitea s3 archive-tar archive-zip compression-tar-gz compression-zip-deflate compression-zip-bzip2 signatures s3-auth checksums"
 ```
 
 ## README Sync
@@ -135,16 +150,21 @@ cargo test --no-default-features --features "ureq native-tls github gitlab gitea
 ---
 
 ## Mandatory Verification After Every Change
-After making **any** code change, run these in order and do not present the change as complete until all pass:
-1. **Format** — `cargo fmt`
-2. **Lint** — `cargo clippy` on **both** clients (commands above)
-3. **Test** — `cargo test` on **both** clients (commands above)
-4. If `src/lib.rs` changed — `./readme.sh && ./readme.sh check`
+The single command that runs everything CI enforces is **`make ci`** — fmt, README drift check,
+clippy and tests across every lane (reqwest, ureq, async), the `--all-features` build, and every
+backend example build. This is exactly what `.github/workflows/build.yml` runs, so a green
+`make ci` locally means green CI. Prefer it over running the steps by hand.
 
-The `pr-cycle` skill's helper bundles all of this: `.agents/skills/pr-cycle/pr.py 0 ci`.
-Equivalently, **`make ci`** runs fmt/clippy/tests on both http clients, the README drift
-check, and builds every backend example. Run `make help` to list all targets (e.g.
-`make check`, `make tests/ureq`, `make examples/s3`, `make docs/readme`).
+If you do run the steps individually, run these in order and do not present the change as complete
+until all pass:
+1. **Format** — `cargo fmt`
+2. **Lint** — `cargo clippy` on every lane: reqwest, ureq, async (commands above), or `make check/clippy`
+3. **Test** — `cargo test` on every lane: reqwest, ureq, async (commands above), or `make tests`
+4. If `src/lib.rs` changed — `./readme.sh && ./readme.sh check`, or `make check/readme`
+
+The `pr-cycle` skill's helper also bundles all of this: `.agents/skills/pr-cycle/pr.py 0 ci`.
+Run `make help` to list all targets (e.g. `make check`, `make tests/ureq`, `make examples/s3`,
+`make docs/readme`).
 
 ---
 
@@ -209,7 +229,9 @@ Claude sub-agent definitions used by these skills live in `.claude/agents/`
 | `src/macros.rs` | Crate macros (`cargo_crate_version!`; `impl_common_builder_setters!` + `impl_release_update_accessors!` for the shared backend surface; internal helpers) |
 | `src/version.rs` | Semver comparison helpers |
 | `src/errors.rs` | `Error` / `Result` types (`#[non_exhaustive]`; opaque `Transport` / `S3Auth` variants) |
-| `examples/` | Runnable usage examples, one per backend (`github`, `gitlab`, `gitea`, `s3`) |
+| `examples/` | Runnable usage examples (`github`, `gitlab`, `gitea`, `s3`, `custom`, `embedded_key`) |
+| `tests/` | Integration tests exercising the public API (`custom_transport.rs`, `error_helpers_external.rs`) |
+| `Makefile` | Source of truth for the CI lanes; `make ci` runs everything CI enforces. `make help` lists targets |
 | `readme.sh` | README generation/check wrapper around `cargo-readme` |
 | `CHANGELOG.md` | Keep-a-changelog style; always has an `[unreleased]` section on top |
 | `docs/migrations/` | Per-release migration guides; `PREV-to-X.Y.Z.md` (agent/automation) and `PREV-to-X.Y.Z-human.md` (human). Current: `0.x-to-1.0.md` / `0.x-to-1.0-human.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## [unreleased]
 
+### Added
+- `ReleaseSource` / `AsyncReleaseSource`: `get_latest_release` and `get_release_version` have
+  default implementations derived from `get_releases` (newest-by-semver pick and exact version
+  match, both order-independent), so a custom source only has to implement `get_releases`.
+  Existing implementations are unaffected; override the defaults when the host has cheaper
+  dedicated endpoints. New trait methods will only be added with defaults, so implementations
+  keep compiling across minor releases.
+- `Releases::with_current_version(v)`: attach a current version to an already-fetched listing
+  (e.g. from `ReleaseList::fetch`) so `is_update_available()` works, without rebuilding via
+  `into_vec` / `from_releases`.
+- `Error::transport(source)`: build the `Transport` variant from an error value or a message
+  string, for custom `HttpClient` / `AsyncHttpClient` implementations.
+- `ReleaseBuilder::new()`, equivalent to `Release::builder()`.
+
+### Changed
+- `ReleaseBuilder::build()` validates that the version parses as bare semver and errors with
+  `Error::SemVer` otherwise (a `v` prefix or a non-semver tag previously built fine and was
+  silently skipped, or errored opaquely, later in the update pipeline).
+- All requests send the same `self_update/<version>` User-Agent when the caller has not set one
+  via `request_header`. Previously github sent `rust/self-update` and gitlab/gitea and the
+  standalone `Download` sent `rust-reqwest/self-update` (wrong under the `ureq` client).
+- `ProgressStyle` is `#[non_exhaustive]`: construct with `ProgressStyle::new(template, chars)`
+  instead of a struct literal. Field reads are unaffected.
+- The `ArchiveNotEnabled` Display message matches the other variants' style (lowercase after the
+  prefix, no trailing punctuation).
+
+### Fixed
+- The `ReleaseSource` / `AsyncReleaseSource` docs told implementors to construct error variants
+  with struct literals, which does not compile downstream (the variants are `#[non_exhaustive]`);
+  they now reference the public constructors (`Error::http_status_error`, `Error::transport`,
+  `Error::no_release_found`, ...).
+- docs.rs feature badges (`doc(cfg)`) on `AsyncHttpClient`, `AsyncHttpResponse`, and the
+  `ReqwestClient` / `ReqwestAsyncClient` / `UreqClient` re-exports.
+- The `MoveAll` doc example staged its sources in `/tmp`, which fails with a cross-device error
+  since `commit()` renames; it now stages next to the destinations.
+- The features docs note that a client without a TLS feature only supports plain-`http` URLs.
+- The updater `is_update_available` / `is_update_available_async` docs note that the returned
+  release is the newest available, which is not necessarily the release `update()` installs (the
+  pipeline prefers the newest semver-compatible one).
+- The github and gitea `Update` builders set their auth scheme explicitly instead of relying on
+  `AuthScheme::default()` (no behavior change; removes a fragile implicit default).
+
 ## [1.0.0-rc.5]
 Final polish from a full-surface review of rc.4: two breaking `Error`-constructor changes (folded
 into the [1.0 migration guide](docs/migrations/0.x-to-1.0-human.md)), additive constructors and

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ clients and multiple TLS backends may coexist (reqwest is preferred when both ar
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
 
+Note that enabling a client with neither TLS feature compiles (plain-`http` release hosts remain
+reachable) but any `https` URL then fails at request time with a transport error; enable `rustls`
+or `native-tls` for `https`.
+
 The following [cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section)
 are enabled by default:
 
@@ -271,13 +275,15 @@ The custom backend has no `ReleaseList` by design: listing is performed entirely
 
 To update from a host the built-in backends (`github`, `gitlab`, `gitea`, `s3`) don't cover —
 another forge, a private artifact registry, a plain HTTP directory — implement the
-`ReleaseSource` trait (three fetch methods that say *where releases come from*) and drive a full
-update through the `backends::custom` backend, which reuses the crate's compare → select-asset →
-download → verify → extract → install flow. You build `Release`s with `Release::builder` and
+`ReleaseSource` trait and drive a full update through the `backends::custom` backend, which reuses
+the crate's compare → select-asset → download → verify → extract → install flow. Only
+`get_releases` (the fetch that says *where releases come from*) is required;
+`get_latest_release` / `get_release_version` are derived from it by default and can be overridden
+when the host has cheaper dedicated endpoints. You build `Release`s with `Release::builder` and
 `ReleaseAsset::new`; the `ReleaseUpdate` trait stays sealed.
 
 `ReleaseSource` is **synchronous**. For a natively-async source, implement `AsyncReleaseSource`
-(the same three fetches as `async fn`) and drive it through
+(the same fetches as `async fn`) and drive it through
 `backends::custom::AsyncUpdate` + `build_async()`; to reuse a
 `Clone` sync source from the async API, wrap it in
 `backends::custom::Blocking`.
@@ -287,17 +293,11 @@ use self_update::{Release, ReleaseAsset, ReleaseSource, cargo_crate_version};
 
 struct MyHost;
 impl ReleaseSource for MyHost {
-    fn get_latest_release(&self) -> self_update::Result<Release> {
-        Ok(Release::builder()
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
+        Ok(vec![Release::builder()
             .version("1.2.3")
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
-            .build()?)
-    }
-    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
-        Ok(vec![self.get_latest_release()?])
-    }
-    fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
-        self.get_latest_release()
+            .build()?])
     }
 }
 

--- a/docs/migrations/0.x-to-1.0-human.md
+++ b/docs/migrations/0.x-to-1.0-human.md
@@ -495,15 +495,17 @@ If you write a **custom backend** (you `impl ReleaseSource`), a few things chang
 only use the built-in github/gitlab/gitea/s3 backends can skip this section.
 
 **`ReleaseSource` is sync.** It is three plain sync fetch methods (and no `Clone` requirement), with
-no defaulted `*_async` helpers. The sync and async worlds are mirror images of each other, just like
+no defaulted `*_async` helpers. Only `get_releases` is required: `get_latest_release` and
+`get_release_version` have default implementations derived from it (override them when your host
+has cheaper dedicated endpoints). The sync and async worlds are mirror images of each other, just like
 the built-in backends' `build()` vs `build_async()`: `build()` returns the concrete blocking
 `Update`; `build_async()` returns a per-backend `AsyncUpdate` wrapper (e.g. `github::AsyncUpdate`)
 that exposes only the `*_async` verbs as inherent methods (no `use self_update::AsyncReleaseUpdate`
 import needed), so calling a blocking `.update()` on it is a compile error.
 
-- **Native async source:** implement the `AsyncReleaseSource` trait, the same three fetches, with
+- **Native async source:** implement the `AsyncReleaseSource` trait, the same fetches, with
   clean names (`get_latest_release`, `get_releases`, `get_release_version`, **no** `_async`
-  suffix). Drive it with the async custom updater:
+  suffix; only `get_releases` is required). Drive it with the async custom updater:
 
   ```rust,ignore
   use self_update::backends::custom::AsyncUpdate;

--- a/docs/migrations/0.x-to-1.0.md
+++ b/docs/migrations/0.x-to-1.0.md
@@ -590,13 +590,15 @@ Three changes to the custom-backend / `ReleaseUpdate` surface (the async source 
 feature):
 
 **9a. `ReleaseSource` is sync-only.** The trait is three sync fetches plus `Send + Sync`, with no
-`Self: Clone` bound and no defaulted `*_async` helpers. If you implemented or called any
-`get_*_async` default on `ReleaseSource`:
+`Self: Clone` bound and no defaulted `*_async` helpers. Only `get_releases` must be implemented;
+`get_latest_release` and `get_release_version` have defaults derived from it. If you implemented
+or called any `get_*_async` default on `ReleaseSource`:
 
 - For a **natively-async** source, implement the
   [`AsyncReleaseSource`](https://docs.rs/self_update/latest/self_update/trait.AsyncReleaseSource.html)
-  trait instead: the same three fetches with clean names (no `_async` suffix:
-  `get_latest_release`, `get_releases`, `get_release_version`), and drive the update with
+  trait instead: the same fetches with clean names (no `_async` suffix:
+  `get_latest_release`, `get_releases`, `get_release_version`; only `get_releases` is required),
+  and drive the update with
   `self_update::backends::custom::AsyncUpdate::configure().source(..).build_async()?.update_async().await?`
   (mirrors a built-in backend's `build_async()`). The trait requires its returned futures to be
   `Send` (the methods return `impl Future<Output = ...> + Send`), enforced at the impl site rather

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -4,10 +4,11 @@ Example updating an executable from a custom release source (user-defined backen
 `cargo build --example custom --features "archive-tar archive-zip compression-tar-gz compression-zip-deflate"`
 
 Use this when the built-in backends (github, gitlab, gitea, s3) don't cover your host. Implement
-`ReleaseSource` for your host — the three methods that say *where releases come from* — then
-configure a `custom::Update` with the same shared options as any other backend and call `update()`.
-The crate runs its usual compare -> select-asset -> download -> verify -> extract -> install flow
-over your source.
+`ReleaseSource` for your host — only `get_releases`, the fetch that says *where releases come
+from*, is required (`get_latest_release` / `get_release_version` have default implementations
+derived from it) — then configure a `custom::Update` with the same shared options as any other
+backend and call `update()`. The crate runs its usual compare -> select-asset -> download ->
+verify -> extract -> install flow over your source.
 
 With the `async` feature, implement `AsyncReleaseSource` (or wrap a `Clone` sync source in
 `Blocking`) and drive the update through `custom::AsyncUpdate`.
@@ -29,32 +30,34 @@ use self_update::{Release, ReleaseAsset, ReleaseSource, cargo_crate_version};
 struct MyHost;
 
 impl ReleaseSource for MyHost {
-    fn get_latest_release(&self) -> self_update::Result<Release> {
-        // Build a release with one asset. `Release::builder()` is needed because
-        // `Release` is `#[non_exhaustive]` and can't be constructed with a struct
-        // literal from outside the crate.
-        Release::builder()
-            .version("1.2.3")
-            .asset(ReleaseAsset::new(
-                // The asset name must contain the target triple so the crate's
-                // built-in asset selection can match it against the running platform.
-                "myapp-x86_64-unknown-linux-gnu.tar.gz",
-                "https://releases.example.com/myapp/v1.2.3/myapp-x86_64-unknown-linux-gnu.tar.gz",
-            ))
-            .build()
-    }
-
+    // `get_releases` is the only required method: `get_latest_release` and
+    // `get_release_version` are derived from it by default. Override those two
+    // when your host has cheaper dedicated endpoints (a `/latest` route, a
+    // fetch-by-tag lookup).
     fn get_releases(&self) -> self_update::Result<Vec<Release>> {
         // Return the full candidate list. The updater discards releases that are not
         // strictly newer than the current version and picks the newest semver-compatible
         // one, so you do not need to pre-filter by `current`.
-        Ok(vec![self.get_latest_release()?])
+        //
+        // Build each release with `Release::builder()` (`Release` is `#[non_exhaustive]`
+        // and can't be constructed with a struct literal from outside the crate).
+        Ok(vec![
+            Release::builder()
+                .version("1.2.3")
+                .asset(ReleaseAsset::new(
+                    // The asset name must contain the target triple so the crate's
+                    // built-in asset selection can match it against the running platform.
+                    "myapp-x86_64-unknown-linux-gnu.tar.gz",
+                    "https://releases.example.com/myapp/v1.2.3/myapp-x86_64-unknown-linux-gnu.tar.gz",
+                ))
+                .build()?,
+        ])
     }
 
     fn get_release_version(&self, ver: &str) -> self_update::Result<Release> {
-        // Look up a specific tag. In a real implementation this would fetch that
-        // exact version from your API; here we reuse the hardcoded release and
-        // override the version for demonstration.
+        // Optional override: the default scans `get_releases()` for an exact version
+        // match. In a real implementation this would fetch that exact version from
+        // your API; here we build it for demonstration.
         Release::builder()
             .version(ver)
             .asset(ReleaseAsset::new(
@@ -87,29 +90,18 @@ mod async_update {
     struct MyAsyncHost;
 
     impl AsyncReleaseSource for MyAsyncHost {
-        async fn get_latest_release(&self) -> self_update::Result<Release> {
-            // ... your own async HTTP request + parsing ...
-            Release::builder()
-                .version("1.2.3")
-                .asset(ReleaseAsset::new(
-                    "myapp-x86_64-unknown-linux-gnu.tar.gz",
-                    "https://releases.example.com/myapp/v1.2.3/myapp-x86_64-unknown-linux-gnu.tar.gz",
-                ))
-                .build()
-        }
-
+        // As with the sync trait, `get_releases` is the only required method.
         async fn get_releases(&self) -> self_update::Result<Vec<Release>> {
-            Ok(vec![self.get_latest_release().await?])
-        }
-
-        async fn get_release_version(&self, ver: &str) -> self_update::Result<Release> {
-            Release::builder()
-                .version(ver)
-                .asset(ReleaseAsset::new(
-                    format!("myapp-{ver}-x86_64-unknown-linux-gnu.tar.gz"),
-                    format!("https://releases.example.com/myapp/v{ver}/myapp-{ver}-x86_64-unknown-linux-gnu.tar.gz"),
-                ))
-                .build()
+            // ... your own async HTTP request + parsing ...
+            Ok(vec![
+                Release::builder()
+                    .version("1.2.3")
+                    .asset(ReleaseAsset::new(
+                        "myapp-x86_64-unknown-linux-gnu.tar.gz",
+                        "https://releases.example.com/myapp/v1.2.3/myapp-x86_64-unknown-linux-gnu.tar.gz",
+                    ))
+                    .build()?,
+            ])
         }
     }
 

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -2,9 +2,11 @@
 Updates from a user-defined release source.
 
 Use this backend to update from a host the built-in backends (`github`, `gitlab`, `gitea`, `s3`)
-don't cover. Implement [`ReleaseSource`] for your host — the three methods
-that say *where releases come from* — then configure a [`custom::Update`](Update) with the same
-shared options as any other backend (target, bin name, version, progress, transport, checksum,
+don't cover. Implement [`ReleaseSource`] for your host — only
+[`get_releases`](ReleaseSource::get_releases), which says *where releases come from*, is required
+(`get_latest_release` / `get_release_version` are derived from it by default; override them when
+your host has cheaper dedicated endpoints) — then configure a [`custom::Update`](Update) with the
+same shared options as any other backend (target, bin name, version, progress, transport, checksum,
 verify hook, asset matcher, …) and call `update()`. The crate runs its usual compare →
 select-asset → download → verify → extract → install flow over your source; you never touch the
 low-level `Download`/`Extract`/`Move` primitives.
@@ -14,18 +16,12 @@ use self_update::{Release, ReleaseAsset, ReleaseSource, cargo_crate_version};
 
 struct MyHost;
 impl ReleaseSource for MyHost {
-    fn get_latest_release(&self) -> self_update::Result<Release> {
-        // ... your own HTTP request + parsing ...
-        Ok(Release::builder()
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
+        // ... your own HTTP request + parsing, one Release per available version ...
+        Ok(vec![Release::builder()
             .version("1.2.3")
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
-            .build()?)
-    }
-    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
-        Ok(vec![self.get_latest_release()?])
-    }
-    fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
-        self.get_latest_release()
+            .build()?])
     }
 }
 
@@ -65,18 +61,12 @@ use self_update::backends::custom::AsyncUpdate;
 
 struct MyHost;
 impl AsyncReleaseSource for MyHost {
-    async fn get_latest_release(&self) -> self_update::Result<Release> {
-        // ... your own async HTTP request + parsing ...
-        Ok(Release::builder()
+    async fn get_releases(&self) -> self_update::Result<Vec<Release>> {
+        // ... your own async HTTP request + parsing, one Release per available version ...
+        Ok(vec![Release::builder()
             .version("1.2.3")
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
-            .build()?)
-    }
-    async fn get_releases(&self) -> self_update::Result<Vec<Release>> {
-        Ok(vec![self.get_latest_release().await?])
-    }
-    async fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
-        self.get_latest_release().await
+            .build()?])
     }
 }
 
@@ -103,9 +93,7 @@ use self_update::backends::custom::{AsyncUpdate, Blocking};
 # #[derive(Clone)]
 # struct MySyncHost;
 # impl self_update::ReleaseSource for MySyncHost {
-#     fn get_latest_release(&self) -> self_update::Result<self_update::Release> { unimplemented!() }
 #     fn get_releases(&self) -> self_update::Result<Vec<self_update::Release>> { unimplemented!() }
-#     fn get_release_version(&self, _: &str) -> self_update::Result<self_update::Release> { unimplemented!() }
 # }
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 let _builder = AsyncUpdate::configure()

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -324,6 +324,9 @@ impl UpdateBuilder {
             },
             common: {
                 let mut resolved = self.common.build()?;
+                // Gitea authenticates with `token <token>`; set the scheme explicitly rather than
+                // relying on `AuthScheme::default()` (gitlab overrides to `Bearer` the same way).
+                resolved.request.auth_scheme = crate::backends::common::AuthScheme::Token;
                 resolved.request.auth_base_host = self
                     .host
                     .as_deref()
@@ -581,7 +584,7 @@ fn api_headers() -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::USER_AGENT,
-        "rust-reqwest/self-update"
+        crate::DEFAULT_USER_AGENT
             .parse()
             .expect("gitea invalid user-agent"),
     );
@@ -1239,7 +1242,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "rust-reqwest/self-update"
+            crate::DEFAULT_USER_AGENT
         );
         assert!(
             headers

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -195,8 +195,8 @@ impl ReleaseList {
         let api_url = format!(
             "{}/repos/{}/{}/releases",
             self.custom_url
-                .as_ref()
-                .unwrap_or(&"https://api.github.com".to_string()),
+                .as_deref()
+                .unwrap_or("https://api.github.com"),
             urlencoding::encode(&self.repo_owner),
             urlencoding::encode(&self.repo_name)
         );
@@ -218,8 +218,8 @@ impl ReleaseList {
         let api_url = format!(
             "{}/repos/{}/{}/releases",
             self.custom_url
-                .as_ref()
-                .unwrap_or(&"https://api.github.com".to_string()),
+                .as_deref()
+                .unwrap_or("https://api.github.com"),
             urlencoding::encode(&self.repo_owner),
             urlencoding::encode(&self.repo_name)
         );
@@ -296,6 +296,9 @@ impl UpdateBuilder {
             custom_url: self.custom_url.clone(),
             common: {
                 let mut resolved = self.common.build()?;
+                // Github authenticates with `token <token>`; set the scheme explicitly rather than
+                // relying on `AuthScheme::default()` (gitlab overrides to `Bearer` the same way).
+                resolved.request.auth_scheme = crate::backends::common::AuthScheme::Token;
                 // The github API host (asset download URLs are on the same host) receives the token;
                 // a server-supplied URL on any other host does not.
                 resolved.request.auth_base_host = crate::backends::common::host_of(
@@ -559,15 +562,16 @@ impl crate::update::AsyncReleaseUpdate for Update {
     }
 }
 
-/// Build github's base request headers (its `rust/self-update` User-Agent). The Authorization
-/// header is no longer set here: the auth scheme/token is applied centrally by the shared
+/// Build github's base request headers (the shared `self_update/<version>` User-Agent; github
+/// rejects requests with no User-Agent). The Authorization header is no longer set here: the auth
+/// scheme/token is applied centrally by the shared
 /// [`apply_auth`](crate::backends::common::RequestConfig::apply_auth) on both the listing and
 /// download paths, which also honors a user `request_header(AUTHORIZATION, ..)` override.
 fn api_headers() -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::USER_AGENT,
-        "rust/self-update"
+        crate::DEFAULT_USER_AGENT
             .parse()
             .expect("github invalid user-agent"),
     );
@@ -1474,9 +1478,9 @@ mod tests {
     #[test]
     fn api_headers_override_uses_github_user_agent() {
         // The `{api_headers}` override arm of `impl_update_config_accessors!` must wire github's
-        // custom `api_headers` (its `rust/self-update` User-Agent), not the trait default (which
-        // sets no User-Agent). After B5 the auth scheme/token is no longer baked into `api_headers`;
-        // it is applied centrally by `apply_auth` (asserted in
+        // custom `api_headers` (the shared `self_update/<version>` User-Agent), not the trait
+        // default (which sets no User-Agent). The auth scheme/token is not baked into
+        // `api_headers`; it is applied centrally by `apply_auth` (asserted in
         // `github_token_scheme_applied_to_both_paths`).
         let upd = super::Update::configure()
             .repo_owner("o")
@@ -1492,7 +1496,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "rust/self-update"
+            crate::DEFAULT_USER_AGENT
         );
         assert!(
             headers
@@ -2209,8 +2213,8 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "rust/self-update",
-            "api_headers() must set the rust/self-update User-Agent"
+            crate::DEFAULT_USER_AGENT,
+            "api_headers() must set the shared self_update User-Agent"
         );
         assert!(
             headers
@@ -2253,9 +2257,10 @@ mod tests {
             "exactly two HTTP requests must be issued"
         );
         // Both requests must carry the User-Agent header.
+        let expected_ua = format!("user-agent: {}", crate::DEFAULT_USER_AGENT.to_lowercase());
         for (i, req) in requests.iter().enumerate() {
             assert!(
-                req.to_lowercase().contains("user-agent: rust/self-update"),
+                req.to_lowercase().contains(&expected_ua),
                 "page {} request is missing the User-Agent header:\n{}",
                 i + 1,
                 req

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -577,7 +577,7 @@ fn api_headers() -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
     headers.insert(
         header::USER_AGENT,
-        "rust-reqwest/self-update"
+        crate::DEFAULT_USER_AGENT
             .parse()
             .expect("gitlab invalid user-agent"),
     );
@@ -1356,7 +1356,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "rust-reqwest/self-update"
+            crate::DEFAULT_USER_AGENT
         );
         assert!(
             headers
@@ -1991,7 +1991,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "rust-reqwest/self-update",
+            crate::DEFAULT_USER_AGENT,
             "api_headers() (no-arg form) must still set the User-Agent header"
         );
         assert!(
@@ -2031,10 +2031,11 @@ mod tests {
 
         let reqs = captured.lock().unwrap();
         assert_eq!(reqs.len(), 2, "both pages must have been requested");
+        let expected_ua = format!("user-agent: {}", crate::DEFAULT_USER_AGENT.to_lowercase());
         for (i, req) in reqs.iter().enumerate() {
             let lower = req.to_lowercase();
             assert!(
-                lower.contains("user-agent: rust-reqwest/self-update"),
+                lower.contains(&expected_ua),
                 "page {} request must carry User-Agent header; got:\n{}",
                 i + 1,
                 req

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -192,8 +192,8 @@ impl ReleaseListBuilder {
         self
     }
 
-    #[cfg(feature = "s3-auth")]
     /// Set the access key
+    #[cfg(feature = "s3-auth")]
     pub fn access_key(&mut self, access_key: impl Into<auth::AccessKey>) -> &mut Self {
         self.access_key = Some(access_key.into());
         self
@@ -416,8 +416,8 @@ impl UpdateBuilder {
         self
     }
 
-    #[cfg(feature = "s3-auth")]
     /// Set the access key (an `(access_key_id, secret_access_key)` pair)
+    #[cfg(feature = "s3-auth")]
     pub fn access_key(&mut self, access_key: impl Into<auth::AccessKey>) -> &mut Self {
         self.access_key = Some(access_key.into());
         self
@@ -1888,12 +1888,12 @@ mod tests {
     /// path rather than a fully-buffered `String` (audit I7).
     struct XmlResponse {
         body: Vec<u8>,
+        headers: crate::http_client::HeaderMap,
     }
 
     impl crate::http_client::HttpResponse for XmlResponse {
         fn headers(&self) -> &crate::http_client::HeaderMap {
-            // Leak a fresh empty map so the borrow lives long enough; never read in this test.
-            Box::leak(Box::new(crate::http_client::HeaderMap::new()))
+            &self.headers
         }
         fn body(self: Box<Self>) -> Box<dyn std::io::Read> {
             Box::new(std::io::Cursor::new(self.body))
@@ -1909,6 +1909,7 @@ mod tests {
         let xml = list_bucket_xml(&["myapp-1.2.3-x86_64-linux"]);
         let resp: Box<dyn crate::http_client::HttpResponse> = Box::new(XmlResponse {
             body: xml.into_bytes(),
+            headers: crate::http_client::HeaderMap::new(),
         });
         let reader = resp.body_buffered();
         let releases = parse_s3_response(
@@ -1968,11 +1969,15 @@ mod tests {
             .version("1.0.0")
             .build()
             .unwrap();
-        let empty_ver = Release::builder()
-            .name("myapp")
-            .version("")
-            .build()
-            .unwrap();
+        // An empty version cannot come out of `ReleaseBuilder::build` (it validates semver), but
+        // the s3 listing parser constructs `Release`s directly, so the guard is still reachable.
+        let empty_ver = Release {
+            name: "myapp".into(),
+            version: "".into(),
+            date: "".into(),
+            body: None,
+            assets: Vec::new(),
+        };
         super::add_to_releases_list(&mut releases, empty_name);
         super::add_to_releases_list(&mut releases, empty_ver);
         assert!(
@@ -2807,7 +2812,9 @@ mod tests {
     }
 
     fn rel(version: &str) -> Release {
-        Release::builder().version(version).build().unwrap()
+        // Raw construction: the junk-version tests below need versions `ReleaseBuilder::build`
+        // rejects (stored s3 keys are parsed directly, so junk can still reach the pipeline).
+        crate::update::testing::release_with_raw_version(version)
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -316,6 +316,15 @@ impl Error {
         status_to_error(status, &url.into())
     }
 
+    /// Construct a [`Transport`](Error::Transport) error wrapping the underlying
+    /// connection/TLS/timeout failure, for a custom [`HttpClient`](crate::http_client::HttpClient) /
+    /// [`AsyncHttpClient`](crate::http_client::AsyncHttpClient) whose request could not be
+    /// completed. Accepts an error value or a message string:
+    /// `Error::transport(io_err)` / `Error::transport("connection reset by proxy")`.
+    pub fn transport(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Error {
+        Error::Transport(source.into())
+    }
+
     /// Construct a [`VerificationRejected`](Error::VerificationRejected) error with the given
     /// reason, for rejecting the extracted binary from a `verify_binary` hook:
     ///
@@ -411,7 +420,7 @@ impl std::fmt::Display for Error {
             Zip(e) => write!(f, "ZipError: {}", e),
             ArchiveNotEnabled(s) => write!(
                 f,
-                "ArchiveNotEnabledError: Archive extension '{}' not supported, please enable 'archive-{}' feature!",
+                "ArchiveNotEnabledError: archive extension '{}' not supported; enable the 'archive-{}' feature",
                 s, s
             ),
             CompressionNotEnabled(s) => write!(
@@ -1165,8 +1174,15 @@ mod tests {
             shown
         );
         assert!(
-            shown.contains("zip"),
-            "ArchiveNotEnabled Display must contain the extension, got: {}",
+            shown.contains("zip") && shown.contains("archive-zip"),
+            "ArchiveNotEnabled Display must contain the extension and the feature name, got: {}",
+            shown
+        );
+        // Message style matches the other variants: lowercase after the prefix, no trailing
+        // punctuation.
+        assert!(
+            !shown.ends_with('!') && !shown.ends_with('.'),
+            "ArchiveNotEnabled Display must not end with punctuation, got: {}",
             shown
         );
     }

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -10,10 +10,13 @@ mod reqwest;
 mod ureq;
 
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use reqwest::ReqwestAsyncClient;
 #[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use reqwest::ReqwestClient;
 #[cfg(feature = "ureq")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ureq")))]
 pub use ureq::UreqClient;
 
 /// Object-safe HTTP transport seam. The crate only ever issues GETs, so `get` is the whole
@@ -64,6 +67,7 @@ pub trait HttpResponse {
 /// the crate root (`self_update::futures_util`, `self_update::bytes`), so an implementation does
 /// not need them as direct dependencies.
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub trait AsyncHttpClient: Send + Sync {
     /// Issue a GET, returning a boxed future resolving to the status-checked response.
     fn get<'a>(
@@ -77,6 +81,7 @@ pub trait AsyncHttpClient: Send + Sync {
 /// Async sibling of [`HttpResponse`]. Drives the streamed download (`bytes_stream`) instead of
 /// leaking a concrete `reqwest::Response`.
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub trait AsyncHttpResponse: Send {
     /// The response headers.
     fn headers(&self) -> &HeaderMap<HeaderValue>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@ clients and multiple TLS backends may coexist (reqwest is preferred when both ar
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
 
+Note that enabling a client with neither TLS feature compiles (plain-`http` release hosts remain
+reachable) but any `https` URL then fails at request time with a transport error; enable `rustls`
+or `native-tls` for `https`.
+
 The following [cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section)
 are enabled by default:
 
@@ -276,13 +280,15 @@ The custom backend has no `ReleaseList` by design: listing is performed entirely
 
 To update from a host the built-in backends (`github`, `gitlab`, `gitea`, `s3`) don't cover —
 another forge, a private artifact registry, a plain HTTP directory — implement the
-`ReleaseSource` trait (three fetch methods that say *where releases come from*) and drive a full
-update through the `backends::custom` backend, which reuses the crate's compare → select-asset →
-download → verify → extract → install flow. You build `Release`s with `Release::builder` and
+`ReleaseSource` trait and drive a full update through the `backends::custom` backend, which reuses
+the crate's compare → select-asset → download → verify → extract → install flow. Only
+`get_releases` (the fetch that says *where releases come from*) is required;
+`get_latest_release` / `get_release_version` are derived from it by default and can be overridden
+when the host has cheaper dedicated endpoints. You build `Release`s with `Release::builder` and
 `ReleaseAsset::new`; the `ReleaseUpdate` trait stays sealed.
 
 `ReleaseSource` is **synchronous**. For a natively-async source, implement `AsyncReleaseSource`
-(the same three fetches as `async fn`) and drive it through
+(the same fetches as `async fn`) and drive it through
 `backends::custom::AsyncUpdate` + `build_async()`; to reuse a
 `Clone` sync source from the async API, wrap it in
 `backends::custom::Blocking`.
@@ -292,17 +298,11 @@ use self_update::{Release, ReleaseAsset, ReleaseSource, cargo_crate_version};
 
 struct MyHost;
 impl ReleaseSource for MyHost {
-    fn get_latest_release(&self) -> self_update::Result<Release> {
-        Ok(Release::builder()
+    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
+        Ok(vec![Release::builder()
             .version("1.2.3")
             .asset(ReleaseAsset::new("app-x86_64-unknown-linux-gnu.tar.gz", "https://host/app.tar.gz"))
-            .build()?)
-    }
-    fn get_releases(&self) -> self_update::Result<Vec<Release>> {
-        Ok(vec![self.get_latest_release()?])
-    }
-    fn get_release_version(&self, _ver: &str) -> self_update::Result<Release> {
-        self.get_latest_release()
+            .build()?])
     }
 }
 
@@ -570,6 +570,11 @@ pub use checksum::Checksum;
 
 use http_client::header;
 
+/// The User-Agent sent on the crate's own requests (API listings and downloads) when the caller
+/// has not set one via `request_header`. One shared value so every backend and the standalone
+/// [`Download`] identify themselves the same way regardless of the compiled HTTP client.
+pub(crate) const DEFAULT_USER_AGENT: &str = concat!("self_update/", env!("CARGO_PKG_VERSION"));
+
 #[cfg(feature = "progress-bar")]
 pub(crate) const DEFAULT_PROGRESS_TEMPLATE: &str =
     "[{elapsed_precise}] [{bar:40}] {bytes}/{total_bytes} ({eta}) {msg}";
@@ -596,6 +601,7 @@ pub(crate) const DEFAULT_PROGRESS_CHARS: &str = "=>-";
 #[cfg(feature = "progress-bar")]
 #[cfg_attr(docsrs, doc(cfg(feature = "progress-bar")))]
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ProgressStyle {
     /// The `indicatif` progress-bar template (see `indicatif::ProgressStyle::template`).
     pub template: String,
@@ -1219,9 +1225,11 @@ fn rename_or_copy(source: &path::Path, dest: &path::Path) -> Result<()> {
 /// // The stash dir must be on the same filesystem as the destinations (rename can't cross
 /// // filesystems), so create it next to them rather than in $TMPDIR.
 /// let tmp = tempfile::TempDir::new_in("/usr/local")?;
-/// // `new_bin` / `new_lib` are files you already extracted into a temp dir.
-/// let new_bin = std::path::Path::new("/tmp/extracted/app");
-/// let new_lib = std::path::Path::new("/tmp/extracted/libapp.so");
+/// // `new_bin` / `new_lib` are files you already extracted into a staging dir, which must
+/// // also be on the destination filesystem (the sources are renamed into place too).
+/// let staging = tempfile::TempDir::new_in("/usr/local")?;
+/// let new_bin = staging.path().join("app");
+/// let new_lib = staging.path().join("libapp.so");
 /// self_update::MoveAll::from_temp(tmp.path())
 ///     .add(new_bin, "/usr/local/bin/app")
 ///     .add(new_lib, "/usr/local/lib/libapp.so")
@@ -1671,9 +1679,7 @@ impl Download {
         if !headers.contains_key(header::USER_AGENT) {
             headers.insert(
                 header::USER_AGENT,
-                "rust-reqwest/self-update"
-                    .parse()
-                    .expect("invalid user-agent"),
+                DEFAULT_USER_AGENT.parse().expect("invalid user-agent"),
             );
         }
 
@@ -1783,9 +1789,7 @@ impl Download {
         if !headers.contains_key(header::USER_AGENT) {
             headers.insert(
                 header::USER_AGENT,
-                "rust-reqwest/self-update"
-                    .parse()
-                    .expect("invalid user-agent"),
+                DEFAULT_USER_AGENT.parse().expect("invalid user-agent"),
             );
         }
 
@@ -1879,9 +1883,6 @@ impl Download {
 
 #[cfg(test)]
 mod tests {
-    #![allow(dead_code, unused_mut, unused_variables)]
-    // #![warn(unused_mut)]
-
     use super::*;
     #[cfg(feature = "compression-tar-gz")]
     use flate2::{self, write::GzEncoder};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -358,6 +358,11 @@ macro_rules! impl_sync_update_verbs {
             ///
             /// A convenience over [`get_newer_releases`](Self::get_newer_releases): returns the
             /// newest strictly-newer [`Release`](crate::Release), or `None` when already up to date.
+            ///
+            /// Note that the returned release is the newest *available*, which is not necessarily
+            /// the one [`update`](Self::update) would install: the update pipeline prefers the
+            /// newest semver-*compatible* release and falls back to the newest available only when
+            /// no compatible one exists.
             pub fn is_update_available(&self) -> crate::Result<Option<crate::Release>> {
                 Ok(self.get_newer_releases()?.into_vec().into_iter().next())
             }
@@ -416,6 +421,11 @@ macro_rules! impl_async_update_verbs {
             /// A convenience over [`get_newer_releases_async`](Self::get_newer_releases_async):
             /// returns the newest strictly-newer [`Release`](crate::Release), or `None` when already
             /// up to date.
+            ///
+            /// Note that the returned release is the newest *available*, which is not necessarily
+            /// the one [`update_async`](Self::update_async) would install: the update pipeline
+            /// prefers the newest semver-*compatible* release and falls back to the newest
+            /// available only when no compatible one exists.
             pub async fn is_update_available_async(&self) -> crate::Result<Option<crate::Release>> {
                 Ok(self
                     .get_newer_releases_async()

--- a/src/update.rs
+++ b/src/update.rs
@@ -216,8 +216,14 @@ pub struct ReleaseBuilder {
 }
 
 impl ReleaseBuilder {
+    /// Create an empty builder; equivalent to [`Release::builder`].
+    pub fn new() -> ReleaseBuilder {
+        ReleaseBuilder::default()
+    }
+
     /// Set the release version (required), e.g. `"1.2.3"`. This is what the updater compares against
-    /// the current version, so it should be a bare semver string (no leading `v`).
+    /// the current version, so it must be a bare semver string (no leading `v`);
+    /// [`build`](Self::build) rejects anything `semver` cannot parse.
     pub fn version(&mut self, version: impl Into<String>) -> &mut Self {
         self.version = Some(version.into());
         self
@@ -253,12 +259,19 @@ impl ReleaseBuilder {
         self
     }
 
-    /// Validate and build the [`Release`]. Errors if `version` was not set.
+    /// Validate and build the [`Release`].
+    ///
+    /// Errors with [`Error::MissingField`] if `version` was not set, and with [`Error::SemVer`] if
+    /// it is not a bare semver string (e.g. a leading `v`, or a non-semver tag). Validating here
+    /// gives a clear error at construction time; an unparseable version stored in a `Release` would
+    /// otherwise surface only later, as a silently-skipped release or an opaque comparison error
+    /// inside the update pipeline.
     pub fn build(&self) -> Result<Release> {
         let version = self
             .version
             .clone()
             .ok_or(Error::MissingField { field: "version" })?;
+        semver::Version::parse(&version)?;
         Ok(Release {
             name: Arc::from(self.name.clone().unwrap_or_else(|| version.clone())),
             version: Arc::from(version),
@@ -322,6 +335,27 @@ impl Releases {
             releases,
             current_version: Some(current_version.into()),
         }
+    }
+
+    /// Attach (or replace) the current version to compare against, consuming and returning the
+    /// listing. Turns a bare listing (e.g. from `ReleaseList::fetch`) into one where
+    /// [`is_update_available`](Self::is_update_available) works, without tearing it down via
+    /// [`into_vec`](Self::into_vec) / [`from_releases`](Self::from_releases):
+    ///
+    /// ```rust,no_run
+    /// # fn run() -> self_update::Result<()> {
+    /// let available = self_update::backends::github::ReleaseList::configure()
+    ///     .repo_owner("jaemk")
+    ///     .repo_name("self_update")
+    ///     .build()?
+    ///     .fetch()?
+    ///     .with_current_version(self_update::cargo_crate_version!())
+    ///     .is_update_available()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_current_version(mut self, current_version: impl Into<String>) -> Self {
+        self.current_version = Some(current_version.into());
+        self
     }
 
     /// All fetched releases, newest-first.
@@ -441,17 +475,32 @@ impl<'a> IntoIterator for &'a Releases {
 /// sync `ReleaseSource` from the async API, wrap it in
 /// [`backends::custom::Blocking`](crate::backends::custom::Blocking).
 ///
-/// On failure, return one of the public [`Error`] variants. For a completed
-/// request with a non-2xx status use the structured variants — e.g.
-/// `Error::HttpStatus { status: 503, url: "…".into() }` for a transient server error, or
-/// `Error::NotFound { url: "…".into() }` for a missing resource — and `Error::Transport(…)` for a
-/// request that could not be completed (connection refused, DNS, TLS, timeout). For release-level
-/// failures use `Error::NoReleaseFound { target }` (no release / no matching asset) or
-/// `Error::MissingAssetField { field }` (a missing field in a release/asset payload), and for
-/// configuration errors `Error::MissingField { field }`.
+/// On failure, return one of the public [`Error`] variants via its constructor (the structured
+/// variants are `#[non_exhaustive]`, so they cannot be built with a struct literal from outside the
+/// crate). For a completed request with a non-2xx status use
+/// [`Error::http_status_error`] — e.g. `Error::http_status_error(503, url)` for a transient server
+/// error or `Error::http_status_error(404, url)` for a missing resource — and [`Error::transport`]
+/// for a request that could not be completed (connection refused, DNS, TLS, timeout). For
+/// release-level failures use [`Error::no_release_found`] /
+/// [`Error::no_release_found_for_target`] (no release / no matching asset) or
+/// [`Error::missing_asset_field`] (a missing field in a release/asset payload), and
+/// [`Error::invalid_response`] for a response body that failed to parse.
+///
+/// Only [`get_releases`](Self::get_releases) is required. The other two methods have default
+/// implementations derived from it; override them when your host offers a cheaper dedicated
+/// endpoint (e.g. a `/latest` route, or a fetch-by-tag lookup). New methods may be added to this
+/// trait in minor releases, but only with a default implementation, so implementations keep
+/// compiling.
 pub trait ReleaseSource: Send + Sync {
     /// Fetch the single newest release.
-    fn get_latest_release(&self) -> Result<Release>;
+    ///
+    /// The default implementation fetches [`get_releases`](Self::get_releases) and picks the
+    /// newest by semver comparison (order-independent, so an unsorted source is still correct).
+    /// Errors with [`Error::NoReleaseFound`](crate::Error::NoReleaseFound) when the source has no
+    /// releases. Override to use a dedicated latest-release endpoint.
+    fn get_latest_release(&self) -> Result<Release> {
+        newest_release(self.get_releases()?)
+    }
 
     /// Fetch the candidate releases, **newest first**. Return all the releases you want considered;
     /// the updater discards any that are not strictly newer than the current version, prefers the
@@ -461,8 +510,34 @@ pub trait ReleaseSource: Send + Sync {
     /// ensures the right release is chosen.
     fn get_releases(&self) -> Result<Vec<Release>>;
 
-    /// Fetch the release for an explicit tag/version.
-    fn get_release_version(&self, ver: &str) -> Result<Release>;
+    /// Fetch the release for an explicit version.
+    ///
+    /// The default implementation fetches [`get_releases`](Self::get_releases) and returns the
+    /// first release whose version equals `ver` exactly (the bare semver string, no leading `v`).
+    /// Errors with [`Error::NoReleaseFound`](crate::Error::NoReleaseFound) when nothing matches.
+    /// Override to use a dedicated fetch-by-tag endpoint.
+    fn get_release_version(&self, ver: &str) -> Result<Release> {
+        release_for_version(self.get_releases()?, ver)
+    }
+}
+
+/// The newest release by semver comparison, shared by the `ReleaseSource` /
+/// `AsyncReleaseSource` `get_latest_release` defaults. Order-independent; on a version tie the
+/// earliest-positioned release wins.
+fn newest_release(releases: Vec<Release>) -> Result<Release> {
+    releases
+        .into_iter()
+        .min_by(|a, b| version::cmp_releases_newest_first(a.version(), b.version()))
+        .ok_or_else(Error::no_release_found)
+}
+
+/// The first release whose version equals `ver` exactly, shared by the `ReleaseSource` /
+/// `AsyncReleaseSource` `get_release_version` defaults.
+fn release_for_version(releases: Vec<Release>, ver: &str) -> Result<Release> {
+    releases
+        .into_iter()
+        .find(|r| r.version() == ver)
+        .ok_or_else(Error::no_release_found)
 }
 
 /// An async source of releases for a custom update backend.
@@ -490,32 +565,54 @@ pub trait ReleaseSource: Send + Sync {
 /// [`backends::custom::Blocking`](crate::backends::custom::Blocking), which runs the sync fetches
 /// on [`tokio::task::spawn_blocking`].
 ///
-/// On failure, return one of the public [`Error`] variants. For a completed
-/// request with a non-2xx status use the structured variants — e.g.
-/// `Error::HttpStatus { status: 503, url: "…".into() }` for a transient server error, or
-/// `Error::NotFound { url: "…".into() }` for a missing resource — and `Error::Transport(…)` for a
-/// request that could not be completed (connection refused, DNS, TLS, timeout). For release-level
-/// failures use `Error::NoReleaseFound { target }` (no release / no matching asset) or
-/// `Error::MissingAssetField { field }` (a missing field in a release/asset payload), and for
-/// configuration errors `Error::MissingField { field }`.
+/// On failure, return one of the public [`Error`] variants via its constructor (the structured
+/// variants are `#[non_exhaustive]`, so they cannot be built with a struct literal from outside the
+/// crate). For a completed request with a non-2xx status use
+/// [`Error::http_status_error`] — e.g. `Error::http_status_error(503, url)` for a transient server
+/// error or `Error::http_status_error(404, url)` for a missing resource — and [`Error::transport`]
+/// for a request that could not be completed (connection refused, DNS, TLS, timeout). For
+/// release-level failures use [`Error::no_release_found`] /
+/// [`Error::no_release_found_for_target`] (no release / no matching asset) or
+/// [`Error::missing_asset_field`] (a missing field in a release/asset payload), and
+/// [`Error::invalid_response`] for a response body that failed to parse.
+///
+/// Only [`get_releases`](Self::get_releases) is required. The other two methods have default
+/// implementations derived from it; override them when your host offers a cheaper dedicated
+/// endpoint (e.g. a `/latest` route, or a fetch-by-tag lookup). New methods may be added to this
+/// trait in minor releases, but only with a default implementation, so implementations keep
+/// compiling.
 #[cfg(feature = "async")]
 pub trait AsyncReleaseSource: Send + Sync {
     /// Fetch the single newest release.
     ///
+    /// The default implementation fetches [`get_releases`](Self::get_releases) and picks the
+    /// newest by semver comparison (order-independent, so an unsorted source is still correct).
+    /// Errors with [`Error::NoReleaseFound`](crate::Error::NoReleaseFound) when the source has no
+    /// releases. Override to use a dedicated latest-release endpoint.
+    ///
     /// The returned future must be `Send` (it is awaited inside the updater). This is enforced at
     /// the impl site via the `+ Send` bound on the return type, so a non-`Send` implementation
     /// fails to compile here rather than later at the spawn site.
-    fn get_latest_release(&self) -> impl std::future::Future<Output = Result<Release>> + Send + '_;
+    fn get_latest_release(&self) -> impl std::future::Future<Output = Result<Release>> + Send + '_ {
+        async move { newest_release(self.get_releases().await?) }
+    }
 
     /// Fetch the candidate releases, **newest first**. See
     /// [`ReleaseSource::get_releases`] for how the updater treats the returned list.
     fn get_releases(&self) -> impl std::future::Future<Output = Result<Vec<Release>>> + Send + '_;
 
-    /// Fetch the release for an explicit tag/version.
+    /// Fetch the release for an explicit version.
+    ///
+    /// The default implementation fetches [`get_releases`](Self::get_releases) and returns the
+    /// first release whose version equals `ver` exactly (the bare semver string, no leading `v`).
+    /// Errors with [`Error::NoReleaseFound`](crate::Error::NoReleaseFound) when nothing matches.
+    /// Override to use a dedicated fetch-by-tag endpoint.
     fn get_release_version<'a>(
         &'a self,
         ver: &'a str,
-    ) -> impl std::future::Future<Output = Result<Release>> + Send + 'a;
+    ) -> impl std::future::Future<Output = Result<Release>> + Send + 'a {
+        async move { release_for_version(self.get_releases().await?, ver) }
+    }
 }
 
 /// The async counterpart of [`ReleaseUpdate`], implemented by every backend's `Update` (and the
@@ -908,6 +1005,20 @@ pub(crate) mod testing {
         current_version: &str,
     ) -> Result<Option<Release>> {
         choose_latest_release(releases, current_version, false)
+    }
+
+    /// Construct a [`Release`] with a raw (possibly non-semver) version string, bypassing
+    /// [`ReleaseBuilder::build`]'s semver validation. The backends build `Release`s directly from
+    /// whatever tag a forge returns, so junk versions can reach the pipeline; tests of the
+    /// pipeline's junk tolerance need to fabricate them.
+    pub(crate) fn release_with_raw_version(version: &str) -> Release {
+        Release {
+            name: Arc::from(version),
+            version: Arc::from(version),
+            date: Arc::from(""),
+            body: None,
+            assets: Vec::new(),
+        }
     }
 }
 
@@ -1359,7 +1470,10 @@ mod tests {
     use crate::update::Release;
 
     fn rel(version: &str) -> Release {
-        Release::builder().version(version).build().unwrap()
+        // Raw construction: several tests below exercise the pipeline's tolerance of non-semver
+        // versions, which `ReleaseBuilder::build` rejects (the backends build `Release`s directly
+        // from forge tags, so junk can still reach the pipeline).
+        super::testing::release_with_raw_version(version)
     }
 
     // --- Releases (D1) ------------------------------------------------------------------------
@@ -1455,6 +1569,156 @@ mod tests {
                 .expect("a found update wins over a later parse error"),
             "2.0.0 > 1.0.0 must return true before reaching the bad entry"
         );
+    }
+
+    #[test]
+    fn releases_with_current_version_enables_is_update_available() {
+        // A bare listing (no current version) errors with NoCurrentVersion; attaching one via
+        // with_current_version turns it into a comparable listing without rebuilding.
+        let bare = Releases::from_listing(vec![rel("2.0.0"), rel("1.0.0")]);
+        assert!(matches!(
+            bare.is_update_available(),
+            Err(crate::errors::Error::NoCurrentVersion)
+        ));
+        let with_version = bare.with_current_version("1.0.0");
+        assert_eq!(with_version.current_version(), Some("1.0.0"));
+        assert!(with_version.is_update_available().unwrap());
+        // It also replaces an existing current version.
+        let replaced =
+            Releases::from_releases(vec![rel("2.0.0")], "1.0.0").with_current_version("2.0.0");
+        assert!(!replaced.is_update_available().unwrap());
+    }
+
+    #[test]
+    fn release_builder_new_matches_release_builder() {
+        // `ReleaseBuilder::new()` is the conventional entry; it must behave exactly like
+        // `Release::builder()`.
+        let a = super::ReleaseBuilder::new()
+            .version("1.2.3")
+            .build()
+            .unwrap();
+        let b = Release::builder().version("1.2.3").build().unwrap();
+        assert_eq!(a.version(), b.version());
+        assert_eq!(a.name(), b.name());
+    }
+
+    #[test]
+    fn release_builder_build_rejects_non_semver_versions() {
+        // A `v` prefix or a non-semver tag must fail at build() with Error::SemVer instead of
+        // being stored and silently dropped (or erroring opaquely) later in the pipeline.
+        for bad in ["v1.2.3", "latest", "not-a-version", ""] {
+            let err = Release::builder()
+                .version(bad)
+                .build()
+                .expect_err(&format!("version {bad:?} must be rejected"));
+            assert!(
+                matches!(err, crate::errors::Error::SemVer(_)),
+                "expected Error::SemVer for {bad:?}, got {err:?}"
+            );
+        }
+        // Valid semver still builds, including pre-release and build metadata.
+        for good in ["1.2.3", "2.0.0-alpha.1", "1.0.0+build.5"] {
+            Release::builder()
+                .version(good)
+                .build()
+                .unwrap_or_else(|e| panic!("version {good:?} must build: {e}"));
+        }
+    }
+
+    #[test]
+    fn release_builder_missing_version_is_missing_field() {
+        // The unset-version error stays MissingField (not SemVer).
+        let err = Release::builder().name("x").build().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::errors::Error::MissingField { field } if field == "version"
+            ),
+            "expected MissingField {{ field: \"version\" }}"
+        );
+    }
+
+    // --- ReleaseSource default methods ----------------------------------------------------------
+
+    struct ListOnlySource(Vec<Release>);
+
+    impl super::ReleaseSource for ListOnlySource {
+        fn get_releases(&self) -> Result<Vec<Release>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn release_source_default_get_latest_release_picks_newest_unsorted() {
+        // Only get_releases is implemented; the default get_latest_release must pick the newest
+        // by semver even when the source returns an unsorted list.
+        use super::ReleaseSource;
+        let source = ListOnlySource(vec![rel("1.0.0"), rel("2.1.0"), rel("1.5.0")]);
+        assert_eq!(source.get_latest_release().unwrap().version(), "2.1.0");
+    }
+
+    #[test]
+    fn release_source_default_get_latest_release_errors_when_empty() {
+        use super::ReleaseSource;
+        let source = ListOnlySource(vec![]);
+        assert!(matches!(
+            source.get_latest_release(),
+            Err(crate::errors::Error::NoReleaseFound { .. })
+        ));
+    }
+
+    #[test]
+    fn release_source_default_get_release_version_finds_exact_match() {
+        use super::ReleaseSource;
+        let source = ListOnlySource(vec![rel("2.0.0"), rel("1.5.0"), rel("1.0.0")]);
+        assert_eq!(
+            source.get_release_version("1.5.0").unwrap().version(),
+            "1.5.0"
+        );
+        // No match (including a v-prefixed query; the default matches the stored bare semver
+        // exactly) errors with NoReleaseFound.
+        assert!(matches!(
+            source.get_release_version("v1.5.0"),
+            Err(crate::errors::Error::NoReleaseFound { .. })
+        ));
+        assert!(matches!(
+            source.get_release_version("9.9.9"),
+            Err(crate::errors::Error::NoReleaseFound { .. })
+        ));
+    }
+
+    #[cfg(feature = "async")]
+    struct AsyncListOnlySource(Vec<Release>);
+
+    #[cfg(feature = "async")]
+    impl super::AsyncReleaseSource for AsyncListOnlySource {
+        async fn get_releases(&self) -> Result<Vec<Release>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_release_source_default_methods_derive_from_get_releases() {
+        use super::AsyncReleaseSource;
+        let source = AsyncListOnlySource(vec![rel("1.0.0"), rel("2.1.0"), rel("1.5.0")]);
+        assert_eq!(
+            source.get_latest_release().await.unwrap().version(),
+            "2.1.0"
+        );
+        assert_eq!(
+            source.get_release_version("1.5.0").await.unwrap().version(),
+            "1.5.0"
+        );
+        assert!(matches!(
+            source.get_release_version("9.9.9").await,
+            Err(crate::errors::Error::NoReleaseFound { .. })
+        ));
+        let empty = AsyncListOnlySource(vec![]);
+        assert!(matches!(
+            empty.get_latest_release().await,
+            Err(crate::errors::Error::NoReleaseFound { .. })
+        ));
     }
 
     #[test]

--- a/tests/error_helpers_external.rs
+++ b/tests/error_helpers_external.rs
@@ -131,6 +131,28 @@ fn checksum_mismatch_constructable_from_outside() {
     assert_eq!(err.url(), None);
 }
 
+// `Error::transport` builds the `Transport` variant from either an error value or a message
+// string, so a custom `HttpClient` can report a failed request without spelling out the
+// `Box<dyn Error + Send + Sync>` conversion.
+#[test]
+fn transport_constructor_from_outside() {
+    // From an error value: source() chains to it.
+    let err = Error::transport(std::io::Error::other("connection reset"));
+    assert!(matches!(err, Error::Transport(_)));
+    let src = err.source().expect("Error::transport must chain source()");
+    assert!(src.to_string().contains("connection reset"), "got: {src}");
+    let shown = err.to_string();
+    assert!(shown.starts_with("TransportError: "), "got: {shown}");
+
+    // From a message string.
+    let err = Error::transport("proxy refused the request");
+    assert!(matches!(err, Error::Transport(_)));
+    assert!(
+        err.to_string().contains("proxy refused the request"),
+        "got: {err}"
+    );
+}
+
 // `Error::Io` wraps `std::io::Error` which itself implements `std::error::Error`.
 // The `source()` chain works end-to-end from outside the crate.
 #[test]


### PR DESCRIPTION
- Add default `get_latest_release` / `get_release_version` impls on `ReleaseSource` / `AsyncReleaseSource`, derived from `get_releases` (only `get_releases` is required for a custom source; new trait methods will only be added with defaults)
- Add `Releases::with_current_version(v)` so a fetched bare listing can run `is_update_available()` without `into_vec` / `from_releases`
- Add `Error::transport(source)` for custom `HttpClient` / `AsyncHttpClient` impls, and `ReleaseBuilder::new()`
- Validate the version in `ReleaseBuilder::build()` as bare semver (`Error::SemVer`); a bad version previously surfaced later as a silently-skipped release or an opaque comparison error
- Unify the request User-Agent to `self_update/<version>` across github/gitlab/gitea and `Download` (github sent `rust/self-update`, the rest `rust-reqwest/self-update`, wrong under ureq)
- Mark `ProgressStyle` `#[non_exhaustive]`; set the github/gitea `AuthScheme` explicitly in `build_update`
- Fix the `ReleaseSource` docs' error guidance to use the public `Error` constructors (the struct literals shown are `E0639` downstream); add missing `doc(cfg)` badges on `http_client` items; fix the `MoveAll` example's cross-filesystem staging; note that `is_update_available` can return a different release than `update()` installs; note that a TLS-less client build is plain-http only
- Update AGENTS.md: prefer the `make` verification lanes, document the async lane, `tests/`, and the Makefile

CHANGELOG `[unreleased]` and both 1.0 migration guides updated; `make ci` green on all lanes.