### PR TITLE
feat: verify downloads against release-published asset digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [unreleased]
 
 ### Added
+- Release-published digest verification (`checksums` feature): github publishes a `sha256:<hex>`
+  digest per release asset, and the updater now verifies the downloaded artifact against it
+  before installing whenever the selected asset carries one. On by default with the `checksums`
+  feature; opt out with `verify_release_digest(false)` on the builders. A digest that is present
+  but malformed or uses an unsupported algorithm fails the update rather than silently skipping.
+  Independent of `verify_checksum` (when both apply, both must pass), and an integrity check
+  only -- the forge recomputes the digest when an asset is replaced, so it is not a substitute
+  for the `signatures` feature. ([#159](https://github.com/jaemk/self_update/issues/159))
+- `ReleaseAsset::digest()`: the asset's content digest in `algorithm:hex` form, when the backend
+  publishes one (github fills it; gitlab/gitea/s3 have none). `ReleaseAsset::with_digest(..)`
+  attaches one when building assets in a custom `ReleaseSource`.
+- `Checksum::parse_digest("sha256:<hex>")`: parse an `algorithm:hex` digest string (the form
+  forges publish) into a `Checksum`; `sha256` and `sha512` are supported.
 - `ReleaseSource` / `AsyncReleaseSource`: `get_latest_release` and `get_release_version` have
   default implementations derived from `get_releases` (newest-by-semver pick and exact version
   match, both order-independent), so a custom source only has to implement `get_releases`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## [unreleased]
 
 ### Added
+
+### Changed
+
+### Removed
+
+## [1.0.0-rc.6]
+Additive over rc.5: automatic verification against github's per-asset release digests, default
+`ReleaseSource` trait methods, and assorted constructors; plus non-semver-tag skipping in the
+forge listings and a unified User-Agent. No breaking changes vs rc.5, so no migration is needed.
+
+### Added
 - Release-published digest verification (`checksums` feature): github publishes a `sha256:<hex>`
   digest per release asset, and the updater now verifies the downloaded artifact against it
   before installing whenever the selected asset carries one. On by default with the `checksums`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self_update"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 description = "Self updates for standalone executables"
 repository = "https://github.com/jaemk/self_update"
 keywords = ["update", "upgrade", "download", "release"]

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ is intentionally not feature-gated: gating it behind `cfg(feature = "async")` wo
 successfully-compiling doctest in the crate's no-`async` test lanes, which a `compile_fail` block
 must never do):
 
-```rust,compile_fail
+```rust
 fn wont_compile() -> Result<(), Box<dyn std::error::Error>> {
     let updater = self_update::backends::github::Update::configure()
         .repo_owner("jaemk")

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following are opt-in; activate the one(s) your release files need:
 * `compression-zip-deflate`: support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;
-* `checksums`: verify a downloaded artifact against a known SHA-256/SHA-512 checksum (e.g. from a `SHA256SUMS` file) before installing it;
+* `checksums`: verify a downloaded artifact against a SHA-256/SHA-512 checksum before installing it -- automatically against the digest github publishes per release asset, and/or against a known checksum you pass in (e.g. from a `SHA256SUMS` file); see [Checksum verification](#checksum-verification) below;
 * `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest serves the async path, and the sync API prefers reqwest when both are present); see [Async](#async) below.
 
 `github` is the only backend in the default feature set. The S3 backend requires the `s3` feature; `s3-auth` implies `s3`. `gitlab` and `gitea` each require their own feature.
@@ -211,11 +211,23 @@ fn update() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Checksum verification
 
-With the `checksums` feature, pass a known digest (e.g. one published in a `SHA256SUMS` file
-alongside the release) and the crate verifies the downloaded artifact against it **before**
-installing — a mismatch aborts the update. The algorithm is chosen by the
-`Checksum` variant (`Sha256` / `Sha512`); it complements the `signatures`
-feature (zipsign), which verifies authenticity rather than a published digest.
+With the `checksums` feature, the crate verifies the downloaded artifact against a digest
+**before** installing — a mismatch aborts the update. Two sources of digests, independently
+applied (when both apply, both must pass):
+
+- **Release-published digests, automatic.** GitHub publishes a `sha256:<hex>` digest per release
+  asset; the updater verifies the download against it whenever the selected asset carries one.
+  This is on by default with the `checksums` feature — no configuration needed — and can be
+  disabled with `verify_release_digest(false)`. The other backends' APIs publish no digest, so
+  the check is a no-op there (a custom `ReleaseSource` can supply one via
+  `ReleaseAsset::with_digest`). Note this is an *integrity* check only — the forge recomputes
+  the digest if an asset is replaced — so it is not a substitute for the `signatures` feature.
+- **A known digest you pass explicitly** (e.g. one published in a `SHA256SUMS` file alongside
+  the release) via `verify_checksum`. The algorithm is chosen by the `Checksum` variant
+  (`Sha256` / `Sha512`).
+
+Both complement the `signatures` feature (zipsign), which verifies authenticity rather than a
+published digest.
 
 ```rust
 fn update() -> Result<(), Box<dyn std::error::Error>> {

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,9 +4,10 @@ Every feature is documented here before or as it lands, with its status.
 
 ## Feature status
 
-Status values: `done` (implemented and covered by tests), `pending` (documented,
-not yet built; the default), `research` (needs investigation or design before it
-can be built). Keep each row's status current with `spec.py set`.
+Status values: `done` (implemented and covered by tests), `partial` (the core is
+built and tested, with a documented sub-item still deferred), `pending`
+(documented, not yet built; the default), `research` (needs investigation or
+design before it can be built). Keep each row's status current with `spec.py set`.
 
 | Feature | Status | Spec |
 |---------|--------|------|
@@ -40,7 +41,7 @@ can be built). Keep each row's status current with `spec.py set`.
 | Error Variant Granularity | done | [error-variant-granularity.md](error-variant-granularity.md) |
 | S3 Max Keys Configurable | done | [s3-max-keys-configurable.md](s3-max-keys-configurable.md) |
 | Async Future Extensions | pending | [async-future-extensions.md](async-future-extensions.md) |
-| Checksum from Asset | pending | [checksum-from-asset.md](checksum-from-asset.md) |
+| Checksum from Asset | partial | [checksum-from-asset.md](checksum-from-asset.md) |
 | Update Config Internal Accessors | done | [update-config-internal-accessors.md](update-config-internal-accessors.md) |
 | Releases Test Constructor | done | [releases-test-constructor.md](releases-test-constructor.md) |
 | Choose Latest Release Sort | done | [choose-latest-release-sort.md](choose-latest-release-sort.md) |

--- a/specs/checksum-from-asset.md
+++ b/specs/checksum-from-asset.md
@@ -1,27 +1,36 @@
 # Checksum from release asset
 
-Status: not implemented
+Status: partially implemented
 
 ## Problem
 
 Checksum verification requires the caller to pin or fetch the expected digest and pass
-it via `checksum(Checksum::Sha256(hex))` (see `checksum-verification.md`). Many
-projects publish a `SHA256SUMS` or per-asset `.sha256` file in the same release, so the
-digest is already available but the caller has to fetch and parse it themselves.
+it via `verify_checksum(Checksum::Sha256(hex))` (see `checksum-verification.md`). The
+digest is often already published alongside the release, so the caller having to fetch
+and parse it is friction.
 
-## What it would take
+## Implemented: forge-published per-asset digest
 
-A setter such as `checksum_from_asset("SHA256SUMS")` that, during the update, downloads
-the named sums asset from the same release, parses it (the loosely standardized
-`<hex>  <filename>` line format, or a bare digest for a single-asset `.sha256`), and
-matches the line for the selected asset to derive the expected digest. It reuses the
-existing compare-before-install machinery; only the digest source changes. The parsing
-must tolerate the format variations (two spaces vs one, a `*` binary marker, leading
-paths).
+Github publishes a `sha256:<hex>` content digest per release asset. The github backend
+reads it into `ReleaseAsset::digest()` (`None` on gitlab/gitea/s3, whose APIs publish
+none; a custom `ReleaseSource` attaches one via `ReleaseAsset::with_digest`). Under the
+`checksums` feature the update pipeline verifies the download against that digest by
+default, gated by the `verify_release_digest(bool)` builder setter. The forge form is
+parsed by `Checksum::parse_digest("algorithm:hex")` (`sha256`/`sha512`); an unsupported
+or malformed digest is a hard error, not a silent skip. See
+`ref-signatures-and-checksums.md` for the full behavior and the CHANGELOG `[unreleased]`
+Added entry.
 
-## Why deferred
+The digest is an integrity check only (the forge recomputes it when an asset is
+replaced), so it is not a substitute for the `signatures` feature.
 
-This is sugar over the implemented caller-provided checksum, which already covers the
-verification need. It adds an extra network request and format-parsing surface, so it
-waits until there is demand for the convenience. Tracked as the follow-on to the
-caller-pinned digest.
+## Deferred: SHA256SUMS-file fetch and parse
+
+Still not implemented: a setter such as `checksum_from_asset("SHA256SUMS")` that, during
+the update, downloads a named sums asset from the same release, parses the loosely
+standardized `<hex>  <filename>` line format (or a bare digest for a single-asset
+`.sha256`), and matches the line for the selected asset to derive the expected digest.
+This is sugar over the caller-provided checksum and adds an extra network request plus
+format-parsing surface (two spaces vs one, a `*` binary marker, leading paths), so it
+waits until there is demand. The forge-published digest above covers the common github
+case without any of it.

--- a/specs/checksum-verification.md
+++ b/specs/checksum-verification.md
@@ -16,7 +16,9 @@ The crate hashes the downloaded artifact and compares before installing; a misma
 aborts with nothing installed. The hash algorithm is selected by the `Checksum`
 variant, which is `#[non_exhaustive]` so more algorithms can be added later. The
 caller pins or fetches the expected digest, so there is no extra network request and
-no sums-file parsing. Fetching the digest from a release asset is a separate deferred
-item (see `checksum-from-asset.md`).
+no sums-file parsing.
+
+Verifying against the digest the forge itself publishes per asset (rather than a
+caller-pinned one) is a related, now-implemented path: see `checksum-from-asset.md`.
 
 See the `checksums` feature in `Cargo.toml` and the CHANGELOG `[1.0.0]` Added entry.

--- a/specs/ref-common-config.md
+++ b/specs/ref-common-config.md
@@ -25,13 +25,15 @@ backend's `UpdateBuilder` is configured. Each backend's builder embeds it as a
 auto-derived from `bin_name`), `show_download_progress`, `show_output`,
 `no_confirm`, `current_version`, `release_tag`, `progress_template`,
 `progress_chars`, `auth_token`, `progress_callback`, `verify`, `asset_matcher`,
-`checksum` (under `checksums`), and `verifying_keys` (under `signatures`).
+`checksum` and `verify_release_digest` (under `checksums`), and `verifying_keys`
+(under `signatures`).
 
 `Default` (`common.rs:113-140`) sets the non-`None` defaults:
 `bin_path_in_archive_auto = false`, `show_download_progress = false`,
 `show_output = true`, `no_confirm = false`,
 `progress_template = DEFAULT_PROGRESS_TEMPLATE`,
-`progress_chars = DEFAULT_PROGRESS_CHARS`, and `verifying_keys = vec![]`.
+`progress_chars = DEFAULT_PROGRESS_CHARS`, `verify_release_digest = true` (under
+`checksums`), and `verifying_keys = vec![]`.
 
 `build()` (`common.rs:142-190`) validates and resolves into `CommonConfig`
 (`common.rs:194-216`):
@@ -110,9 +112,12 @@ The `@shared` vocabulary (`macros.rs:231-462`):
   (`macros.rs:405`).
 - `verify_binary(impl Fn(&Path) -> Result<()> ...)` (`macros.rs:589`) - the post-update
   hook on the extracted binary; its doc records the full verification order
-  (`verify_checksum` -> signature/`verifying_keys` -> extract -> `verify_binary` -> replace),
-  so it runs last. `Err(..) => bail` with `Error::VerificationRejected { reason }`.
+  (`verify_checksum` -> release digest -> signature/`verifying_keys` -> extract ->
+  `verify_binary` -> replace), so it runs last. `Err(..) => bail` with
+  `Error::VerificationRejected { reason }`.
 - `verify_checksum(Checksum)` (under `checksums`).
+- `verify_release_digest(bool)` (under `checksums`, default on) - toggles verifying the
+  download against the selected asset's backend-published digest.
 - `verifying_keys(impl Into<Vec<VerifyingKey>>)` (`macros.rs:617`, under
   `signatures`; renamed from `verify_keys`) - **replaces** the key set on each call
   (last call wins, unlike
@@ -133,8 +138,8 @@ for the toggles. The crate-private accessors (`macros.rs:226-263`) live on the
 `pub(crate) trait UpdateInternals` (not the public `UpdateConfig`):
 `request_timeout`, `request_headers`, `request_config`, `request_client`,
 `request_async_client` (`async`), `progress_callback`,
-`verify_callback`, `asset_matcher`, `verify_checksum` (`checksums`), and
-`verify_keys` (`signatures`, reading the `verifying_keys` field). See
+`verify_callback`, `asset_matcher`, `verify_checksum` and `verify_release_digest`
+(`checksums`), and `verify_keys` (`signatures`, reading the `verifying_keys` field). See
 `update-config-internal-accessors.md`.
 
 Three invocation forms: bare `($t)` (`macros.rs:109`) for the default

--- a/specs/ref-feature-flags.md
+++ b/specs/ref-feature-flags.md
@@ -102,9 +102,10 @@ Feature-gated public items:
   `pub type VerifyingKey = [u8; zipsign_api::PUBLIC_KEY_LENGTH]` alias
   (`lib.rs:460-470`), plus the `verifying_keys` builder setter (`macros.rs:617`)
   and the doc-hidden `verify_keys()` accessor (`macros.rs:260`).
-- `checksums`: `pub use checksum::Checksum` (`lib.rs:498-500`) and the
-  `verify_checksum` builder setter (`macros.rs:438-442`) and accessor
-  (`macros.rs:191`).
+- `checksums`: `pub use checksum::Checksum` (`lib.rs:498-500`) with its
+  `parse_digest` associated fn, the `verify_checksum` and `verify_release_digest`
+  builder setters and accessors (`macros.rs`), and `ReleaseAsset::digest()` /
+  `with_digest()` for the backend-published asset digest.
 - All the gated crate-root re-exports above carry
   `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]`, so docs.rs renders a
   feature-gate badge on each (`lib.rs:443,446,453,461,469,499`).

--- a/specs/ref-github-backend.md
+++ b/specs/ref-github-backend.md
@@ -119,7 +119,10 @@ each element:
   `trim_start_matches('v')`.
 
 Asset DTO parsing requires `url` (download URL, else `Error::MissingAssetField { field: "url" }`)
-and `name` (else `Error::MissingAssetField { field: "name" }`).
+and `name` (else `Error::MissingAssetField { field: "name" }`). The optional `digest`
+(github's per-asset `algorithm:hex` content digest, published since mid-2025) maps onto
+`ReleaseAsset::digest()` when present, `None` otherwise; under `checksums` the update
+pipeline verifies the download against it by default (see `ref-signatures-and-checksums.md`).
 
 ### Ordering
 

--- a/specs/ref-release-model.md
+++ b/specs/ref-release-model.md
@@ -19,15 +19,17 @@ fetch-method contract they document; the orchestration helpers
 ### Release and ReleaseAsset
 
 `ReleaseAsset` is a `#[non_exhaustive]` struct deriving `Clone, Debug, Default`
-with two **encapsulated** (`pub(crate)`) fields, declared `name: Arc<str>` then
-`download_url: Arc<str>`. The fields are backed by `Arc<str>` (not `String`) so
-cloning a `ReleaseAsset` (and the `Release` that owns it) bumps a refcount rather
-than reallocating the strings. Because it is `#[non_exhaustive]`, outside code
-cannot build it with a struct literal; `ReleaseAsset::new(name, download_url)`
-(taking `impl Into<String>`, converted to `Arc<str>`) is the public constructor.
-The constructor argument order matches the field declaration order (`name`, then
-`download_url`). The fields are read through getters that return borrows:
-`name(&self) -> &str` and `download_url(&self) -> &str`.
+with three **encapsulated** (`pub(crate)`) fields, declared `name: Arc<str>`,
+`download_url: Arc<str>`, then `digest: Option<Arc<str>>`. The fields are backed by
+`Arc<str>` (not `String`) so cloning a `ReleaseAsset` (and the `Release` that owns
+it) bumps a refcount rather than reallocating the strings. Because it is
+`#[non_exhaustive]`, outside code cannot build it with a struct literal;
+`ReleaseAsset::new(name, download_url)` (taking `impl Into<String>`, converted to
+`Arc<str>`) is the public constructor, with `digest` defaulting to `None`. The
+`digest` (github's per-asset `algorithm:hex` content digest) is attached with the
+chainable `with_digest(impl Into<String>) -> Self`. The fields are read through
+getters that return borrows: `name(&self) -> &str`, `download_url(&self) -> &str`,
+and `digest(&self) -> Option<&str>`.
 
 `Release` is a `#[non_exhaustive]` struct deriving `Clone, Debug, Default` with
 **encapsulated** (`pub(crate)`) fields `name: Arc<str>`, `version: Arc<str>`,
@@ -213,9 +215,11 @@ with `into_vec()`.
 
 ## Public surface
 
-- `pub struct ReleaseAsset` `#[non_exhaustive]` with `pub(crate)` `Arc<str>`
-  fields `name`, `download_url`; `ReleaseAsset::new(name, download_url)`; getters
-  `name() -> &str`, `download_url() -> &str`.
+- `pub struct ReleaseAsset` `#[non_exhaustive]` with `pub(crate)` fields `name:
+  Arc<str>`, `download_url: Arc<str>`, `digest: Option<Arc<str>>`;
+  `ReleaseAsset::new(name, download_url)` and chainable
+  `with_digest(impl Into<String>)`; getters `name() -> &str`,
+  `download_url() -> &str`, `digest() -> Option<&str>`.
 - `pub struct Release` `#[non_exhaustive]` with `pub(crate)` fields (`Arc<str>`
   `name`/`version`/`date`, `Option<Arc<str>>` `body`, `Vec<ReleaseAsset>`
   `assets`); `Release::builder()`, `has_target_asset`, `asset_for`; getters
@@ -248,6 +252,9 @@ with `into_vec()`.
   backing rather than reallocating; both stay `Clone + Debug + Default`.
 - `Deserialize` is not part of the public `Release` / `ReleaseAsset` API; the forge
   backends parse through private per-backend DTOs.
+- `ReleaseAsset::digest()` is populated only by the github backend (from the API's
+  per-asset `digest` field); gitlab/gitea/s3 leave it `None`. A custom
+  `ReleaseSource` attaches one via `with_digest`.
 - `ReleaseList::fetch` returns `Releases` (built via `from_listing`, no current
   version); `into_vec()` recovers the `Vec<Release>`.
 - `asset_for` tier order is target+identifier, then OS+ARCH+identifier, then

--- a/specs/ref-signatures-and-checksums.md
+++ b/specs/ref-signatures-and-checksums.md
@@ -10,6 +10,9 @@ Two independent, opt-in mechanisms:
 - Checksum verification (`checksums` feature): the caller pins a content digest
   they already know (e.g. from a published `SHA256SUMS` file) and the download is
   hashed and compared against it.
+- Release-published digest verification (`checksums` feature): the backend-provided
+  digest of the selected asset (github's per-asset `sha256:<hex>`) is verified
+  automatically, on by default, when the asset carries one.
 - Signature verification (`signatures` feature): zipsign / ed25519ph signatures
   embedded in the archive are verified against caller-supplied public keys.
 
@@ -48,8 +51,30 @@ Verification (`Checksum::verify`, `src/checksum.rs:55`):
   `"ChecksumMismatchError: checksum mismatch (expected <e>, computed <c>)"`
   (`src/errors.rs:153`-`158`). Both fields are lowercase hex digests.
 
-In the pipeline the checksum gate runs first, only when a checksum was configured
-(`src/update.rs:806`-`809`).
+In the pipeline the pinned-checksum gate runs first, only when a checksum was
+configured (`src/update.rs:1314`-`1316`).
+
+### Release-published digest verification
+
+Also gated on the `checksums` feature. The selected asset may carry a
+backend-published content digest in `algorithm:hex` form (github fills
+`ReleaseAsset::digest()` from the release API's per-asset `digest` field;
+gitlab/gitea/s3 leave it `None`, since their APIs publish none). A custom
+`ReleaseSource` supplies one via `ReleaseAsset::with_digest(..)`.
+
+When `verify_release_digest()` is on (the default; opt out with the builder setter
+`verify_release_digest(false)`, `src/macros.rs:713`) and the selected asset carries
+a digest, the digest is parsed with `Checksum::parse_digest` (`src/checksum.rs:54`)
+and verified against the downloaded archive (`src/update.rs:1320`-`1324`).
+`parse_digest` splits on the first `:`, matching `sha256`/`sha512`
+(case-insensitive, surrounding whitespace ignored) onto the `Checksum` variant; an
+unsupported algorithm or a string with no `:` separator returns
+`Error::InvalidResponse` naming the digest, so a present-but-unparseable digest is
+a hard error rather than a silent skip. An absent digest skips the gate.
+
+This gate is independent of the pinned-checksum gate: when both apply, both must
+pass. The digest is an integrity check only (github recomputes it when an asset is
+replaced), so it is not a substitute for signature verification.
 
 ### Signature verification
 
@@ -94,29 +119,37 @@ falls through to `Error::NoSignatures`.
 
 ### Ordering within the pipeline
 
-Inside `finish_update` (`src/update.rs:798`), in order:
+Inside `finish_update_owned` (`src/update.rs:1305`), in order, under
+`#[cfg(feature = "checksums")]` (`src/update.rs:1312`-`1325`):
 
-1. Checksum gate (`#[cfg(feature = "checksums")]`, `src/update.rs:806`-`809`):
-   if a checksum is configured, verify it; mismatch returns immediately via `?`.
-2. Signature gate (`#[cfg(feature = "signatures")]`, `src/update.rs:811`-`812`):
-   `verify_signature` runs; any failure returns via `?`.
-3. Archive extraction of the target binary (`src/update.rs:830`).
-4. Install via `install_binary` (`src/update.rs:837`), which first runs the
-   post-update `verify_binary` callback (renamed from `verify_with`;
-   `src/update.rs:900`-`907`) and only then replaces / moves the binary
-   (`src/update.rs:909`-`912`).
+1. Pinned-checksum gate: if a checksum is configured, verify it; mismatch returns
+   immediately via `?` (`src/update.rs:1314`-`1316`).
+2. Release-digest gate: if `verify_release_digest` is on and the selected asset
+   carries a digest, parse and verify it; a mismatch or unparseable digest returns
+   via `?` (`src/update.rs:1320`-`1324`).
+3. Signature gate (`#[cfg(feature = "signatures")]`): `verify_signature` runs; any
+   failure returns via `?`.
+4. Archive extraction of the target binary.
+5. Install via `install_binary`, which first runs the post-update `verify_binary`
+   callback and only then replaces / moves the binary.
 
-So the full verification order is: checksum, then signature, then (after
-extraction) the `verify_binary` hook, then the binary replacement. The same
-`finish_update` tail is shared by both the sync and async flows
-(`src/update.rs:889`).
+So the full verification order is: pinned checksum, then release digest, then
+signature, then (after extraction) the `verify_binary` hook, then the binary
+replacement. The same `finish_update_owned` tail is shared by both the sync and
+async flows.
 
 ## Public surface
 
 - `self_update::Checksum` enum (`Sha256` / `Sha512`), re-exported under
   `checksums` (`src/lib.rs:500`); `#[non_exhaustive]`.
+- `Checksum::parse_digest("algorithm:hex")` associated fn (`src/checksum.rs:54`),
+  parsing the forge `sha256:<hex>` / `sha512:<hex>` form.
 - `Update::configure().verify_checksum(Checksum)` builder method
-  (`src/macros.rs:439`).
+  (`src/macros.rs:692`).
+- `Update::configure().verify_release_digest(bool)` builder method
+  (`src/macros.rs:713`), default on. `ReleaseAsset::digest()` getter and
+  `ReleaseAsset::with_digest(..)` (`src/update.rs:66`, `src/update.rs:44`) expose
+  and populate the `algorithm:hex` digest.
 - `self_update::VerifyingKey` type alias = `[u8; zipsign_api::PUBLIC_KEY_LENGTH]`,
   re-exported under `signatures` (`src/lib.rs:470`).
 - `self_update::zipsign_api` re-export of the underlying crate, under
@@ -135,7 +168,17 @@ extraction) the `verify_binary` hook, then the binary replacement. The same
   the executable (`src/update.rs:806`-`841`).
 - A checksum mismatch aborts the update: `Checksum::verify` returns
   `Error::ChecksumMismatch` (`src/checksum.rs:61`) propagated by `?`
-  (`src/update.rs:808`), so no extraction or install happens.
+  (`src/update.rs:1314`-`1316`), so no extraction or install happens.
+- The release-digest gate is on by default and only fires when the selected asset
+  carries a digest; `verify_release_digest(false)` skips it. A mismatch aborts via
+  `Error::ChecksumMismatch`, and a present-but-unparseable digest aborts via
+  `Error::InvalidResponse` naming the digest (not a silent skip)
+  (`src/update.rs:1320`-`1324`).
+- The pinned-checksum and release-digest gates are independent: when both apply,
+  both must pass.
+- `ReleaseAsset::digest()` is `None` on gitlab/gitea/s3 (their APIs publish no
+  per-asset digest); only github fills it. The digest is integrity-only (the forge
+  recomputes it if an asset is replaced), not a signature substitute.
 - A signature-verification failure aborts the update via `?`
   (`src/update.rs:812`).
 - Checksum comparison is case-insensitive and trims surrounding whitespace
@@ -163,12 +206,25 @@ extraction) the `verify_binary` hook, then the binary replacement. The same
   produces `Error::ChecksumMismatch` carrying the expected and computed digests;
   `src/checksum.rs:166` `mismatch_display_contains_expected_and_computed` checks the
   `Display` starts with `ChecksumMismatchError:` and embeds both digests.
-- `src/update.rs:1496` `finish_update_rejects_a_mismatched_checksum_before_extracting`:
+- `src/update.rs` `finish_update_rejects_a_mismatched_checksum_before_extracting`:
   a bad checksum aborts at the gate with a "checksum mismatch" message, before any
   extraction.
-- `src/update.rs:1525` `finish_update_passes_a_matching_checksum_then_proceeds`:
+- `src/update.rs` `finish_update_passes_a_matching_checksum_then_proceeds`:
   a matching checksum passes the gate, so the failure instead comes later from
   extraction (proving the gate did not abort).
+- `src/update.rs` `finish_update_rejects_a_mismatched_release_digest_by_default`:
+  with no pinned checksum, a mismatched asset digest aborts at the gate.
+- `src/update.rs` `finish_update_passes_a_matching_release_digest_then_proceeds`:
+  a matching asset digest passes the gate.
+- `src/update.rs` `finish_update_release_digest_opt_out_skips_the_gate`:
+  `verify_release_digest(false)` ignores a mismatched digest.
+- `src/update.rs` `finish_update_rejects_an_unsupported_release_digest`:
+  a `md5:` digest aborts with `Error::InvalidResponse` naming the digest.
+- `src/checksum.rs` `parse_digest_supports_sha256_and_sha512` /
+  `parse_digest_rejects_unsupported_or_malformed`: the `algorithm:hex` parser.
+- `src/backends/github.rs` `github_dto_parses_sample_payload_through_getters`:
+  the API `digest` field maps onto `ReleaseAsset::digest()`; a digest-less asset is
+  `None`.
 - `src/errors.rs:478` checks the signatures-gated non-UTF8 variant is named
   `SignatureNonUTF8`; `src/errors.rs:455` / `src/errors.rs:438` cover the boxed
   `Signature` error's `Display` and `source()`.

--- a/specs/ref-update-pipeline.md
+++ b/specs/ref-update-pipeline.md
@@ -25,9 +25,10 @@ helpers and the same verify/extract/replace tail (`finish_update_owned`).
 
 The verify/extract/replace tail is `finish_update_owned(ctx, dir: TempDir, archive: &Path)`, which
 takes a `FinishCtx` of **owned** fields (install path, target, bin name, in-archive path,
-show_output, the verify callback, and under the features the owned checksum and verifying keys) and
-the `TempDir` moved in by value. The sync `finish_update(&U, release, dir, archive)` builds the ctx
-from the updater and calls the owned twin inline (no spawn). The async path builds the same ctx,
+show_output, the verify callback, and under the features the owned checksum, the selected asset's
+release-published digest plus the `verify_release_digest` flag, and verifying keys) and
+the `TempDir` moved in by value. The sync `finish_update(&U, release, &target_asset, dir, archive)`
+builds the ctx from the updater and the selected asset and calls the owned twin inline (no spawn). The async path builds the same ctx,
 moves the `TempDir` into the closure, and runs `finish_update_owned` inside
 `tokio::task::spawn_blocking(move || ...)`, awaiting the join handle and mapping a `JoinError` to
 `Error::Internal { message, source }`. So the async update never blocks the executor on the verify/extract/replace work,
@@ -85,19 +86,26 @@ the `zip` crate (`lib.rs:805-885`). The extracted binary is `<tmpdir>/<bin_path>
 In `finish_update`, before any extraction or replacement:
 
 1. **Checksum** (feature `checksums`): if `verify_checksum()` is set, `checksum.verify(archive_path)`
-   on the downloaded archive; a mismatch aborts here (`update.rs:806-809`).
-2. **Signature** (feature `signatures`): `verify_signature(archive_path, verify_keys())`
-   (`update.rs:811`). Empty key set is a no-op; otherwise the archive is detected and verified
+   on the downloaded archive; a mismatch aborts here (`update.rs:1314-1316`).
+2. **Release digest** (feature `checksums`): if `verify_release_digest()` is on (the default) and
+   the selected asset carries a backend-published digest (`ReleaseAsset::digest()`, the
+   `algorithm:hex` form github publishes per asset), the digest is parsed via
+   `Checksum::parse_digest` and verified against the archive (`update.rs:1320-1324`). A digest
+   that is present but malformed or an unsupported algorithm aborts with
+   `Error::InvalidResponse` naming the digest (no silent skip); an absent digest skips the gate.
+   Independent of gate 1: when both apply, both must pass.
+3. **Signature** (feature `signatures`): `verify_signature(archive_path, verify_keys())`
+   (`update.rs:1328`). Empty key set is a no-op; otherwise the archive is detected and verified
    with zipsign (`verify_tar` for `Tar(Some(Gz))`, `verify_zip` for `Zip`), keyed with the
-   archive file name as context; any other kind => `Error::NoSignatures(kind)`
-   (`update.rs:904-947`), whose message names the kind via its `Display` impl
+   archive file name as context; any other kind => `Error::NoSignatures(kind)`,
+   whose message names the kind via its `Display` impl
    (`tar.gz` / `zip` / `tar` / `gz` / `plain`), e.g. "signature verification is only
    implemented for `.tar.gz` and `.zip` assets, not gz files".
 
-Both run on the *downloaded archive bytes* and before extraction. The third hook,
-`verify_binary`, runs later inside `install_binary` (`update.rs:872`) on the *extracted binary*,
-immediately before the swap. Ordering: verify_checksum -> verify_keys -> extract -> verify_binary ->
-replace.
+All three run on the *downloaded archive bytes* and before extraction. The last hook,
+`verify_binary`, runs later inside `install_binary` on the *extracted binary*,
+immediately before the swap. Ordering: verify_checksum -> release digest -> verify_keys ->
+extract -> verify_binary -> replace.
 
 ### Replace
 
@@ -183,9 +191,12 @@ under feature `async`; the free `update::update_extended_async` they route to is
 
 ## Invariants and regression checklist
 
-- Verify-before-replace: checksum and signature both run on the downloaded archive *before*
-  extraction; `verify_binary` runs on the extracted binary *before* the swap. Nothing is
-  replaced if any of the three rejects (`update.rs:778-784`, `872-879`).
+- Verify-before-replace: checksum, release digest, and signature all run on the downloaded
+  archive *before* extraction; `verify_binary` runs on the extracted binary *before* the swap.
+  Nothing is replaced if any of the four rejects (`update.rs:1312-1332`, `1444-1451`).
+- The release-digest gate is on by default under `checksums` and only fires when the selected
+  asset carries a digest; `verify_release_digest(false)` opts out. A present-but-unparseable
+  digest is a hard `Error::InvalidResponse`, not a silent skip (`update.rs:1320-1324`).
 - Order independence: `choose_latest_release` sorts candidates semver-descending and filters
   to strictly-newer, so a custom source's unordered/stale list selects correctly and never
   re-installs the current version (`update.rs:640-711`).
@@ -212,7 +223,11 @@ under feature `async`; the free `update::update_extended_async` they route to is
 sorts-out-of-order / ignores-unparseable / falls-back-to-incompatible);
 `install_binary_aborts_when_verify_rejects`, `install_binary_installs_when_verify_accepts`;
 `finish_update_rejects_a_mismatched_checksum_before_extracting`,
-`finish_update_passes_a_matching_checksum_then_proceeds` (feature-gated). `lib.rs` `mod tests`:
+`finish_update_passes_a_matching_checksum_then_proceeds`,
+`finish_update_rejects_a_mismatched_release_digest_by_default`,
+`finish_update_passes_a_matching_release_digest_then_proceeds`,
+`finish_update_release_digest_opt_out_skips_the_gate`,
+`finish_update_rejects_an_unsupported_release_digest` (feature-gated). `lib.rs` `mod tests`:
 `detect_*` (archive detection), `unpack_*` / `test_extract_into` / `test_extract_file`
 (extraction), `move_all_commits_every_move`, `move_all_rolls_back_on_failure`,
 `move_all_installs_fresh_destinations`, `move_all_second_commit_is_a_noop`,

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -428,6 +428,10 @@ pub(crate) struct CommonBuilderConfig {
     pub asset_matcher: Option<crate::AssetMatcher>,
     #[cfg(feature = "checksums")]
     pub checksum: Option<crate::Checksum>,
+    /// Verify the download against the backend-published asset digest when one is present.
+    /// On by default; `verify_release_digest(false)` opts out.
+    #[cfg(feature = "checksums")]
+    pub verify_release_digest: bool,
     #[cfg(feature = "signatures")]
     pub verifying_keys: Vec<[u8; zipsign_api::PUBLIC_KEY_LENGTH]>,
 }
@@ -458,6 +462,8 @@ impl Default for CommonBuilderConfig {
             asset_matcher: None,
             #[cfg(feature = "checksums")]
             checksum: None,
+            #[cfg(feature = "checksums")]
+            verify_release_digest: true,
             #[cfg(feature = "signatures")]
             verifying_keys: vec![],
         }
@@ -517,6 +523,8 @@ impl CommonBuilderConfig {
             asset_matcher: self.asset_matcher.clone(),
             #[cfg(feature = "checksums")]
             checksum: self.checksum.clone(),
+            #[cfg(feature = "checksums")]
+            verify_release_digest: self.verify_release_digest,
             #[cfg(feature = "signatures")]
             verifying_keys: self.verifying_keys.clone(),
         })
@@ -546,6 +554,8 @@ pub(crate) struct CommonConfig {
     pub asset_matcher: Option<crate::AssetMatcher>,
     #[cfg(feature = "checksums")]
     pub checksum: Option<crate::Checksum>,
+    #[cfg(feature = "checksums")]
+    pub verify_release_digest: bool,
     #[cfg(feature = "signatures")]
     pub verifying_keys: Vec<[u8; zipsign_api::PUBLIC_KEY_LENGTH]>,
 }

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -19,6 +19,9 @@ use serde::Deserialize;
 struct AssetDto {
     name: Option<String>,
     url: Option<String>,
+    /// Content digest in `algorithm:hex` form (e.g. `sha256:2cf24d…`); github publishes one per
+    /// asset since mid-2025. Optional so older payloads (and enterprise instances) still parse.
+    digest: Option<String>,
 }
 
 impl AssetDto {
@@ -27,7 +30,11 @@ impl AssetDto {
         let name = self
             .name
             .ok_or_else(|| Error::missing_asset_field("name"))?;
-        Ok(ReleaseAsset::new(name, download_url))
+        let asset = ReleaseAsset::new(name, download_url);
+        Ok(match self.digest {
+            Some(digest) => asset.with_digest(digest),
+            None => asset,
+        })
     }
 }
 
@@ -1037,17 +1044,19 @@ mod tests {
 
     #[test]
     fn github_dto_parses_sample_payload_through_getters() {
-        // A realistic github release object (tag, name, created_at, body, one asset) must parse via
-        // the private `ReleaseDto` into a public `Release` whose getters return the expected values:
-        // the leading `v` is stripped from the version, the asset `url`/`name` map across, and the
-        // body is carried.
+        // A realistic github release object (tag, name, created_at, body, two assets) must parse
+        // via the private `ReleaseDto` into a public `Release` whose getters return the expected
+        // values: the leading `v` is stripped from the version, the asset `url`/`name`/`digest`
+        // map across (a missing `digest` maps to `None`), and the body is carried.
         let body = r#"{
             "tag_name": "v4.5.6",
             "name": "Release 4.5.6",
             "created_at": "2024-01-02T03:04:05Z",
             "body": "the release notes",
             "assets": [
-                { "name": "app-x86_64-unknown-linux-gnu.tar.gz", "url": "https://api/asset/1" }
+                { "name": "app-x86_64-unknown-linux-gnu.tar.gz", "url": "https://api/asset/1",
+                  "digest": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" },
+                { "name": "app-aarch64-apple-darwin.tar.gz", "url": "https://api/asset/2" }
             ]
         }"#;
         let base = stub(move |_| {
@@ -1066,12 +1075,22 @@ mod tests {
         assert_eq!(rel.name(), "Release 4.5.6");
         assert_eq!(rel.date(), "2024-01-02T03:04:05Z");
         assert_eq!(rel.body(), Some("the release notes"));
-        assert_eq!(rel.assets().len(), 1);
+        assert_eq!(rel.assets().len(), 2);
         assert_eq!(
             rel.assets()[0].name(),
             "app-x86_64-unknown-linux-gnu.tar.gz"
         );
         assert_eq!(rel.assets()[0].download_url(), "https://api/asset/1");
+        assert_eq!(
+            rel.assets()[0].digest(),
+            Some("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
+            "the API's per-asset digest field is carried onto the asset"
+        );
+        assert_eq!(
+            rel.assets()[1].digest(),
+            None,
+            "an asset without a digest field parses with digest None"
+        );
     }
 
     // --- sync/async fetch parity (same plans + parsers) ----------------------------------------

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -36,6 +36,36 @@ pub enum Checksum {
 }
 
 impl Checksum {
+    /// Parse an `algorithm:hex` digest string (e.g. `sha256:2cf24d…`, the form GitHub's release
+    /// API publishes per asset) into a `Checksum`.
+    ///
+    /// Supported algorithms are `sha256` and `sha512` (case-insensitive, surrounding whitespace
+    /// ignored). Any other prefix — or a string with no `:` separator — is rejected with an error
+    /// naming the digest, rather than silently skipping verification.
+    ///
+    /// ```
+    /// use self_update::Checksum;
+    /// let c = Checksum::parse_digest(
+    ///     "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    /// ).unwrap();
+    /// assert!(matches!(c, Checksum::Sha256(_)));
+    /// assert!(Checksum::parse_digest("md5:abc123").is_err());
+    /// ```
+    pub fn parse_digest(digest: &str) -> Result<Self> {
+        let digest = digest.trim();
+        let unsupported = || {
+            Error::invalid_response(format!(
+                "unsupported asset digest `{digest}` (expected `sha256:<hex>` or `sha512:<hex>`)"
+            ))
+        };
+        let (algorithm, hex) = digest.split_once(':').ok_or_else(unsupported)?;
+        match algorithm.trim().to_ascii_lowercase().as_str() {
+            "sha256" => Ok(Checksum::Sha256(hex.to_string())),
+            "sha512" => Ok(Checksum::Sha512(hex.to_string())),
+            _ => Err(unsupported()),
+        }
+    }
+
     /// The expected digest, hex encoded.
     fn expected(&self) -> &str {
         match self {
@@ -99,6 +129,45 @@ mod tests {
         let path = dir.path().join("artifact");
         std::fs::write(&path, contents).unwrap();
         (dir, path)
+    }
+
+    // `parse_digest` maps the `algorithm:hex` forge form onto the matching variant, tolerating
+    // case and surrounding whitespace in the algorithm, and the parsed checksum verifies files.
+    #[test]
+    fn parse_digest_supports_sha256_and_sha512() {
+        let (_dir, path) = write_tmp(b"hello");
+        let sha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        let parsed = Checksum::parse_digest(&format!("sha256:{sha256}")).unwrap();
+        assert!(matches!(parsed, Checksum::Sha256(_)));
+        parsed.verify(&path).unwrap();
+
+        let sha512 = "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043";
+        let parsed = Checksum::parse_digest(&format!("SHA512:{sha512}")).unwrap();
+        assert!(matches!(parsed, Checksum::Sha512(_)));
+        parsed.verify(&path).unwrap();
+
+        Checksum::parse_digest(&format!("  sha256:{sha256}  "))
+            .unwrap()
+            .verify(&path)
+            .unwrap();
+    }
+
+    // An unknown algorithm or a string without the `:` separator is rejected with
+    // `Error::InvalidResponse`, and the message names the offending digest.
+    #[test]
+    fn parse_digest_rejects_unsupported_or_malformed() {
+        for bad in ["md5:abc123", "2cf24dba", "sha256"] {
+            let err = Checksum::parse_digest(bad).unwrap_err();
+            assert!(
+                matches!(err, crate::errors::Error::InvalidResponse { .. }),
+                "expected Error::InvalidResponse for {bad:?}, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(bad),
+                "the error must name the digest, got: {}",
+                err
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ The following are opt-in; activate the one(s) your release files need:
 * `compression-zip-deflate`: support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;
-* `checksums`: verify a downloaded artifact against a known SHA-256/SHA-512 checksum (e.g. from a `SHA256SUMS` file) before installing it;
+* `checksums`: verify a downloaded artifact against a SHA-256/SHA-512 checksum before installing it -- automatically against the digest github publishes per release asset, and/or against a known checksum you pass in (e.g. from a `SHA256SUMS` file); see [Checksum verification](#checksum-verification) below;
 * `async`: add async (`*_async`) update methods alongside the unchanged blocking API; tokio-only, requires `reqwest` (ureq and reqwest can coexist -- reqwest serves the async path, and the sync API prefers reqwest when both are present); see [Async](#async) below.
 
 `github` is the only backend in the default feature set. The S3 backend requires the `s3` feature; `s3-auth` implies `s3`. `gitlab` and `gitea` each require their own feature.
@@ -215,11 +215,23 @@ fn update() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Checksum verification
 
-With the `checksums` feature, pass a known digest (e.g. one published in a `SHA256SUMS` file
-alongside the release) and the crate verifies the downloaded artifact against it **before**
-installing — a mismatch aborts the update. The algorithm is chosen by the
-`Checksum` variant (`Sha256` / `Sha512`); it complements the `signatures`
-feature (zipsign), which verifies authenticity rather than a published digest.
+With the `checksums` feature, the crate verifies the downloaded artifact against a digest
+**before** installing — a mismatch aborts the update. Two sources of digests, independently
+applied (when both apply, both must pass):
+
+- **Release-published digests, automatic.** GitHub publishes a `sha256:<hex>` digest per release
+  asset; the updater verifies the download against it whenever the selected asset carries one.
+  This is on by default with the `checksums` feature — no configuration needed — and can be
+  disabled with `verify_release_digest(false)`. The other backends' APIs publish no digest, so
+  the check is a no-op there (a custom `ReleaseSource` can supply one via
+  `ReleaseAsset::with_digest`). Note this is an *integrity* check only — the forge recomputes
+  the digest if an asset is replaced — so it is not a substitute for the `signatures` feature.
+- **A known digest you pass explicitly** (e.g. one published in a `SHA256SUMS` file alongside
+  the release) via `verify_checksum`. The algorithm is chosen by the `Checksum` variant
+  (`Sha256` / `Sha512`).
+
+Both complement the `signatures` feature (zipsign), which verifies authenticity rather than a
+published digest.
 
 ```rust
 # #[cfg(feature = "checksums")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -256,6 +256,10 @@ macro_rules! impl_update_config_accessors {
             fn verify_checksum(&self) -> Option<&crate::Checksum> {
                 self.common.checksum.as_ref()
             }
+            #[cfg(feature = "checksums")]
+            fn verify_release_digest(&self) -> bool {
+                self.common.verify_release_digest
+            }
             #[cfg(feature = "signatures")]
             fn verifying_keys(&self) -> &[crate::VerifyingKey] {
                 &self.common.verifying_keys
@@ -662,7 +666,8 @@ macro_rules! impl_common_builder_setters {
         ///
         /// This runs **last** in the verification chain and on the **extracted binary**, not the
         /// downloaded archive. The full order is: [`verify_checksum`](Self::verify_checksum) (digest
-        /// of the archive) -> signature ([`verifying_keys`](Self::verifying_keys), over the archive) ->
+        /// of the archive) -> release digest ([`verify_release_digest`](Self::verify_release_digest),
+        /// over the archive) -> signature ([`verifying_keys`](Self::verifying_keys), over the archive) ->
         /// extract -> `verify_binary` (the extracted binary) -> replace. Use
         /// `verify_checksum`/`verifying_keys` to gate the download by content; use `verify_binary` to
         /// gate it by running the new binary. Reject with
@@ -680,9 +685,33 @@ macro_rules! impl_common_builder_setters {
         /// Verify the downloaded artifact against an expected [`Checksum`](crate::Checksum)
         /// (e.g. one published in a `SHA256SUMS` file) before installing it. The algorithm is
         /// chosen by the `Checksum` variant.
+        ///
+        /// Independent of [`verify_release_digest`](Self::verify_release_digest): when both apply,
+        /// both must pass.
         #[cfg(feature = "checksums")]
         pub fn verify_checksum(&mut self, checksum: crate::Checksum) -> &mut Self {
             self.common.checksum = Some(checksum);
+            self
+        }
+
+        /// Verify the downloaded artifact against the digest the backend publishes for the
+        /// selected asset (github's per-asset `digest` field, `sha256:<hex>`), before installing
+        /// it. **On by default** whenever the `checksums` feature is enabled; pass `false` to opt
+        /// out.
+        ///
+        /// The check only runs when the selected asset actually carries a digest — github fills
+        /// it, the other backends don't (their APIs publish none), so it is a no-op there. A
+        /// digest that is present but malformed or uses an unsupported algorithm fails the update
+        /// (loudly, rather than silently skipping); opting out is the escape hatch if a forge
+        /// starts publishing digests this crate can't parse.
+        ///
+        /// Note this is an *integrity* check, not authenticity: the forge recomputes the digest
+        /// if an asset is replaced. Use the `signatures` feature
+        /// ([`verifying_keys`](Self::verifying_keys)) to verify authorship. Independent of
+        /// [`verify_checksum`](Self::verify_checksum): when both apply, both must pass.
+        #[cfg(feature = "checksums")]
+        pub fn verify_release_digest(&mut self, verify: bool) -> &mut Self {
+            self.common.verify_release_digest = verify;
             self
         }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,13 +9,16 @@ use crate::{Download, Extract, Move, VersionStatus, confirm, errors::*, version}
 /// Release asset information.
 ///
 /// The fields are encapsulated (`pub(crate)`, backed by `Arc<str>` to keep clones cheap) and read
-/// through the [`name`](ReleaseAsset::name) / [`download_url`](ReleaseAsset::download_url) getters,
-/// which return borrows. Build one with [`ReleaseAsset::new`].
+/// through the [`name`](ReleaseAsset::name) / [`download_url`](ReleaseAsset::download_url) /
+/// [`digest`](ReleaseAsset::digest) getters, which return borrows. Build one with
+/// [`ReleaseAsset::new`] (plus [`with_digest`](ReleaseAsset::with_digest) when the forge publishes
+/// a content digest for the asset).
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct ReleaseAsset {
     pub(crate) name: Arc<str>,
     pub(crate) download_url: Arc<str>,
+    pub(crate) digest: Option<Arc<str>>,
 }
 
 impl ReleaseAsset {
@@ -28,7 +31,19 @@ impl ReleaseAsset {
         Self {
             name: Arc::from(name.into()),
             download_url: Arc::from(download_url.into()),
+            digest: None,
         }
+    }
+
+    /// Attach the asset's content digest, in `algorithm:hex` form (e.g. `sha256:2cf24d…`).
+    ///
+    /// The github backend fills this from the API's per-asset `digest` field; a custom
+    /// [`ReleaseSource`] can chain this onto [`new`](ReleaseAsset::new) when its forge publishes
+    /// one. With the `checksums` feature the updater verifies the downloaded artifact against this
+    /// digest before installing (see `verify_release_digest` on the builders).
+    pub fn with_digest(mut self, digest: impl Into<String>) -> Self {
+        self.digest = Some(Arc::from(digest.into()));
+        self
     }
 
     /// The asset's file name (e.g. `app-x86_64-unknown-linux-gnu.tar.gz`).
@@ -39,6 +54,17 @@ impl ReleaseAsset {
     /// The asset's download URL.
     pub fn download_url(&self) -> &str {
         &self.download_url
+    }
+
+    /// The asset's content digest in `algorithm:hex` form (e.g. `sha256:2cf24d…`), when the
+    /// backend provides one.
+    ///
+    /// The github backend fills this from the release API's per-asset `digest` field; gitlab,
+    /// gitea, and s3 do not expose one, so it is `None` there. Note the digest is an *integrity*
+    /// check only — the forge recomputes it if an asset is replaced — so it is not a substitute
+    /// for signature verification (the `signatures` feature).
+    pub fn digest(&self) -> Option<&str> {
+        self.digest.as_deref()
     }
 }
 
@@ -812,6 +838,11 @@ pub(crate) trait UpdateInternals: sealed::Sealed {
     #[cfg(feature = "checksums")]
     fn verify_checksum(&self) -> Option<&crate::Checksum>;
 
+    /// Whether to verify the download against the backend-published digest of the selected asset,
+    /// when one is present. On by default.
+    #[cfg(feature = "checksums")]
+    fn verify_release_digest(&self) -> bool;
+
     /// ed25519ph verifying keys to validate a download's authenticity
     #[cfg(feature = "signatures")]
     fn verifying_keys(&self) -> &[crate::VerifyingKey] {
@@ -916,7 +947,13 @@ pub trait ReleaseUpdate: UpdateConfig + UpdateInternals {
         println(show_output, "Downloading...");
         build_download(self, &target_asset)?.download_to(&mut tmp_archive)?;
 
-        finish_update(self, release, tmp_archive_dir, &tmp_archive_path)
+        finish_update(
+            self,
+            release,
+            &target_asset,
+            tmp_archive_dir,
+            &tmp_archive_path,
+        )
     }
 }
 
@@ -1207,14 +1244,28 @@ struct FinishCtx {
     verify_callback: Option<std::sync::Arc<crate::DynVerifyFn>>,
     #[cfg(feature = "checksums")]
     verify_checksum: Option<crate::Checksum>,
+    /// The selected asset's backend-published digest (`algorithm:hex`), if any, verified when
+    /// `verify_release_digest` is on.
+    #[cfg(feature = "checksums")]
+    asset_digest: Option<Arc<str>>,
+    #[cfg(feature = "checksums")]
+    verify_release_digest: bool,
     #[cfg(feature = "signatures")]
     verify_keys: Vec<crate::VerifyingKey>,
 }
 
 impl FinishCtx {
-    /// Capture the owned fields the finish tail needs from the updater and the resolved `release`.
-    fn capture<U: UpdateConfig + UpdateInternals + ?Sized>(u: &U, release: Release) -> Self {
+    /// Capture the owned fields the finish tail needs from the updater, the resolved `release`,
+    /// and the selected `target_asset` (its digest feeds the release-digest gate).
+    #[cfg_attr(not(feature = "checksums"), allow(unused_variables))]
+    fn capture<U: UpdateConfig + UpdateInternals + ?Sized>(
+        u: &U,
+        release: Release,
+        target_asset: &ReleaseAsset,
+    ) -> Self {
         Self {
+            #[cfg(feature = "checksums")]
+            asset_digest: target_asset.digest.clone(),
             release,
             bin_install_path: u.bin_install_path().to_path_buf(),
             target: u.target().to_string(),
@@ -1224,6 +1275,8 @@ impl FinishCtx {
             verify_callback: u.verify_callback(),
             #[cfg(feature = "checksums")]
             verify_checksum: u.verify_checksum().cloned(),
+            #[cfg(feature = "checksums")]
+            verify_release_digest: u.verify_release_digest(),
             #[cfg(feature = "signatures")]
             verify_keys: u.verifying_keys().to_vec(),
         }
@@ -1237,10 +1290,11 @@ impl FinishCtx {
 fn finish_update<U: UpdateConfig + UpdateInternals + ?Sized>(
     u: &U,
     release: Release,
+    target_asset: &ReleaseAsset,
     tmp_archive_dir: tempfile::TempDir,
     tmp_archive_path: &std::path::Path,
 ) -> Result<ReleaseStatus> {
-    let ctx = FinishCtx::capture(u, release);
+    let ctx = FinishCtx::capture(u, release, target_asset);
     finish_update_owned(ctx, tmp_archive_dir, tmp_archive_path)
 }
 
@@ -1256,8 +1310,18 @@ fn finish_update_owned(
     let show_output = ctx.show_output;
 
     #[cfg(feature = "checksums")]
-    if let Some(checksum) = ctx.verify_checksum.as_ref() {
-        checksum.verify(tmp_archive_path)?;
+    {
+        if let Some(checksum) = ctx.verify_checksum.as_ref() {
+            checksum.verify(tmp_archive_path)?;
+        }
+        // The backend-published digest of the selected asset (github's per-asset `digest` field),
+        // verified by default. A present-but-unparseable digest is a hard error rather than a
+        // silent skip; `verify_release_digest(false)` is the escape hatch.
+        if ctx.verify_release_digest
+            && let Some(digest) = ctx.asset_digest.as_deref()
+        {
+            crate::Checksum::parse_digest(digest)?.verify(tmp_archive_path)?;
+        }
     }
 
     #[cfg(feature = "signatures")]
@@ -1367,7 +1431,7 @@ where
     // Run the blocking finish tail (verify/extract/install) off the async executor. Copy out the
     // owned fields, MOVE the TempDir into the closure (it is dropped there), and `.await` the
     // join handle, mapping a JoinError to an update error.
-    let ctx = FinishCtx::capture(u, release);
+    let ctx = FinishCtx::capture(u, release, &target_asset);
     tokio::task::spawn_blocking(move || {
         finish_update_owned(ctx, tmp_archive_dir, &tmp_archive_path)
     })
@@ -1480,7 +1544,7 @@ fn verify_signature(
 
 #[cfg(test)]
 mod tests {
-    use super::{Releases, choose_latest_release, install_binary};
+    use super::{ReleaseAsset, Releases, choose_latest_release, install_binary};
     use crate::Download;
     use crate::DynVerifyFn;
     use crate::errors::Result;
@@ -2498,6 +2562,20 @@ mod tests {
             .unwrap()
     }
 
+    // Build a custom-backend `Update` with no explicit checksum and `verify_release_digest`
+    // as given, to drive the release-digest gate of `finish_update` directly.
+    #[cfg(feature = "checksums")]
+    fn update_with_release_digest(verify: bool) -> crate::backends::custom::Update {
+        crate::backends::custom::Update::configure()
+            .source(BoundSource)
+            .bin_name("app")
+            .target("x86_64-unknown-linux-gnu")
+            .current_version("1.0.0")
+            .verify_release_digest(verify)
+            .build()
+            .unwrap()
+    }
+
     // A configured checksum is actually consulted by `finish_update`: a mismatch aborts the
     // update at the checksum gate, before any extraction or install. If the checksum block were
     // dropped, the bogus archive would instead fail later with a non-checksum error and this
@@ -2512,8 +2590,9 @@ mod tests {
         // A valid-length but wrong SHA-256 digest (the file's real digest is 2cf24dba…).
         let upd = update_with_checksum(crate::Checksum::Sha256("00".repeat(32)));
         let release = Release::builder().version("1.2.3").build().unwrap();
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz");
 
-        let err = super::finish_update(&upd, release, dir, &archive_path)
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
             .expect_err("a mismatched checksum must abort the update");
         let msg = err.to_string();
         assert!(
@@ -2542,14 +2621,129 @@ mod tests {
         let digest = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
         let upd = update_with_checksum(crate::Checksum::Sha256(digest.to_string()));
         let release = Release::builder().version("1.2.3").build().unwrap();
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz");
 
-        let err = super::finish_update(&upd, release, dir, &archive_path)
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
             .expect_err("the bytes are not a real archive, so extraction must fail");
         let msg = err.to_string();
         assert!(
             !msg.contains("checksum mismatch"),
             "a matching checksum must pass the gate; the failure should come from extraction, \
              got: {}",
+            msg
+        );
+    }
+
+    // The release-digest gate is on by default: an asset carrying a backend-published digest that
+    // does not match the download aborts the update at the gate, with no `verify_checksum`
+    // configured at all.
+    #[cfg(feature = "checksums")]
+    #[test]
+    fn finish_update_rejects_a_mismatched_release_digest_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("release.tar.gz");
+        std::fs::write(&archive_path, b"hello").unwrap();
+
+        let upd = update_with_release_digest(true);
+        let release = Release::builder().version("1.2.3").build().unwrap();
+        // A valid-length but wrong digest (the file's real digest is 2cf24dba…).
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz")
+            .with_digest(format!("sha256:{}", "00".repeat(32)));
+
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
+            .expect_err("a mismatched release digest must abort the update");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("checksum mismatch"),
+            "expected a checksum-mismatch abort from the release digest, got: {}",
+            msg
+        );
+    }
+
+    // A matching release digest passes the gate and the flow proceeds (here into extraction,
+    // which fails on the bogus archive bytes — a non-checksum error).
+    #[cfg(all(
+        feature = "checksums",
+        feature = "archive-tar",
+        feature = "compression-tar-gz"
+    ))]
+    #[test]
+    fn finish_update_passes_a_matching_release_digest_then_proceeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("release.tar.gz");
+        std::fs::write(&archive_path, b"hello").unwrap();
+
+        let upd = update_with_release_digest(true);
+        let release = Release::builder().version("1.2.3").build().unwrap();
+        // The real SHA-256 of b"hello", in the forge's `algorithm:hex` form.
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz")
+            .with_digest("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
+            .expect_err("the bytes are not a real archive, so extraction must fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("checksum mismatch"),
+            "a matching release digest must pass the gate; the failure should come from \
+             extraction, got: {}",
+            msg
+        );
+    }
+
+    // `verify_release_digest(false)` opts out: the same mismatched digest is ignored and the flow
+    // proceeds past the gate (failing later at extraction with a non-checksum error).
+    #[cfg(all(
+        feature = "checksums",
+        feature = "archive-tar",
+        feature = "compression-tar-gz"
+    ))]
+    #[test]
+    fn finish_update_release_digest_opt_out_skips_the_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("release.tar.gz");
+        std::fs::write(&archive_path, b"hello").unwrap();
+
+        let upd = update_with_release_digest(false);
+        let release = Release::builder().version("1.2.3").build().unwrap();
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz")
+            .with_digest(format!("sha256:{}", "00".repeat(32)));
+
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
+            .expect_err("the bytes are not a real archive, so extraction must fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("checksum mismatch"),
+            "opting out must skip the release-digest gate; the failure should come from \
+             extraction, got: {}",
+            msg
+        );
+    }
+
+    // A present-but-unsupported digest is a hard error at the gate (naming the digest), not a
+    // silent skip — a forge publishing an algorithm this crate can't parse must be surfaced.
+    #[cfg(feature = "checksums")]
+    #[test]
+    fn finish_update_rejects_an_unsupported_release_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("release.tar.gz");
+        std::fs::write(&archive_path, b"hello").unwrap();
+
+        let upd = update_with_release_digest(true);
+        let release = Release::builder().version("1.2.3").build().unwrap();
+        let asset = ReleaseAsset::new("release.tar.gz", "https://host/release.tar.gz")
+            .with_digest("md5:abc123");
+
+        let err = super::finish_update(&upd, release, &asset, dir, &archive_path)
+            .expect_err("an unsupported digest must abort the update");
+        assert!(
+            matches!(err, crate::errors::Error::InvalidResponse { .. }),
+            "expected Error::InvalidResponse, got {:?}",
+            err
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("md5:abc123"),
+            "the error must name the offending digest, got: {}",
             msg
         );
     }
@@ -3374,6 +3568,10 @@ mod tests {
             verify_callback: None,
             #[cfg(feature = "checksums")]
             verify_checksum: None,
+            #[cfg(feature = "checksums")]
+            asset_digest: None,
+            #[cfg(feature = "checksums")]
+            verify_release_digest: true,
             #[cfg(feature = "signatures")]
             verify_keys: vec![],
         }


### PR DESCRIPTION
Closes #159.

- Verify the downloaded artifact against the digest github publishes per release asset (`sha256:<hex>`) before installing, whenever the selected asset carries one. On by default with the `checksums` feature; opt out with `verify_release_digest(false)` on the builders.
- Fail the update on a digest that is present but malformed or uses an unsupported algorithm, rather than silently skipping.
- Add `ReleaseAsset::digest()` and `ReleaseAsset::with_digest(..)` carrying the `algorithm:hex` digest; the github backend fills it from the API's per-asset `digest` field, the other backends leave it `None` (their APIs publish none). A custom `ReleaseSource` can supply one via `with_digest`.
- Add `Checksum::parse_digest("sha256:<hex>")`, parsing the forge form into a `Checksum` (`sha256`/`sha512`).
- Independent of `verify_checksum`: when both apply, both must pass.

Note that this is an integrity check only, not authenticity: github recomputes the digest when an asset is replaced, so it is not a substitute for the `signatures` feature.