### PR TITLE
add xz, verify_signature, vendored openssl, update strategy, release-notes url, and tag prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   gitlab); `None` for s3. The `show_release_notes(bool)` builder setter shows it (or the release
   body when no URL is available) in the confirmation prompt.
   ([#148](https://github.com/jaemk/self_update/issues/148))
+- `tag_prefix(..)` on the github/gitlab/gitea `Update` builders: derive the version from a
+  monorepo-style tag such as `myapp-1.2.3` (or `myapp-v1.2.3`). Defaults to unset, which trims a
+  leading `v` as before; when set, tags without the prefix are skipped from the listing rather than
+  mis-parsed. ([#76](https://github.com/jaemk/self_update/issues/76))
 
 ### Changed
 - A recognized-but-unsupported compression extension now fails loudly instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,25 @@
 ## [unreleased]
 
 ### Added
+- `compression-tar-xz` feature: decode `.tar.xz` / `.txz` archives and plain `.xz` single-file
+  assets (pure-Rust `lzma-rs`, no C `liblzma` dependency, so it cross-compiles like the rest of the
+  default stack). Opt-in, mirroring `compression-tar-gz`. Adds `Compression::Xz`.
+  ([#143](https://github.com/jaemk/self_update/issues/143))
+- `self_update::verify_signature(archive_path, keys)`: run the same embedded-signature check
+  `update()` performs, standalone, for a caller that stages a download itself (e.g. an installer
+  fetching a companion binary before the update loop exists). Takes `impl AsRef<Path>` and a
+  `&[VerifyingKey]` slice; any-of key semantics, `.tar.gz` / `.zip` only (`signatures` feature).
+  ([#150](https://github.com/jaemk/self_update/issues/150))
+- `native-tls-vendored` feature: build OpenSSL from source and link it statically, for targets
+  where a usable system OpenSSL is awkward (musl, some cross-compiles). Implies `native-tls`;
+  applies to the reqwest client. ([#108](https://github.com/jaemk/self_update/issues/108))
 
 ### Changed
+- A recognized-but-unsupported compression extension now fails loudly instead of silently
+  installing the still-compressed bytes as the binary: a `.tar.xz` / `.txz` / `.xz` asset without
+  the `compression-tar-xz` feature returns `Error::CompressionNotEnabled("xz")` (matching the
+  existing `.gz` handling), rather than writing the compressed archive to the install path.
+  ([#143](https://github.com/jaemk/self_update/issues/143))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
 - `native-tls-vendored` feature: build OpenSSL from source and link it statically, for targets
   where a usable system OpenSSL is awkward (musl, some cross-compiles). Implies `native-tls`;
   applies to the reqwest client. ([#108](https://github.com/jaemk/self_update/issues/108))
+- `UpdateStrategy` and the `update_strategy(..)` builder setter: control which release the unpinned
+  "latest" path installs when several are newer. `Compatible` (default) prefers the newest
+  semver-compatible release, falling back to the newest overall; `Latest` always selects the newest
+  release, even across a major bump. ([#152](https://github.com/jaemk/self_update/issues/152))
+- `Release::release_notes_url()` and `ReleaseBuilder::release_notes_url(..)`: the release page URL,
+  filled by the github/gitlab/gitea backends from the release's `html_url` (`_links.self` for
+  gitlab); `None` for s3. The `show_release_notes(bool)` builder setter shows it (or the release
+  body when no URL is available) in the confirmation prompt.
+  ([#148](https://github.com/jaemk/self_update/issues/148))
 
 ### Changed
 - A recognized-but-unsupported compression extension now fails loudly instead of silently

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ features = [
   "compression-zip-deflate",
   "archive-tar",
   "compression-tar-gz",
+  "compression-tar-xz",
   "signatures",
   "checksums",
   "s3-auth",
@@ -39,10 +40,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 flate2 = { version = "1", optional = true }
+lzma-rs = { version = "0.3", optional = true }
 tar = { version = "0.4", optional = true }
 semver = "1.0"
 zip = { version = "8", default-features = false, features = ["time"], optional = true }
-either = { version = "1", optional = true }
 indicatif = { version = "0.18", optional = true }
 quick-xml = { version = "0.41", optional = true }
 regex = "1"
@@ -81,7 +82,8 @@ archive-zip = ["zip", "zipsign-api?/verify-zip"]
 compression-zip-bzip2 = ["archive-zip", "zip/bzip2"]
 compression-zip-deflate = ["archive-zip", "zip/deflate"]
 archive-tar = ["tar", "zipsign-api?/verify-tar"]
-compression-tar-gz = ["archive-tar", "flate2", "either"]
+compression-tar-gz = ["archive-tar", "flate2"]
+compression-tar-xz = ["archive-tar", "dep:lzma-rs"]
 signatures = ["dep:zipsign-api"]
 checksums = ["dep:sha2"]
 
@@ -97,6 +99,10 @@ async = ["reqwest", "reqwest?/stream", "dep:tokio", "dep:futures-util", "dep:byt
 
 
 native-tls = ["reqwest?/native-tls", "ureq?/native-tls"]
+# Vendored OpenSSL: build OpenSSL from source and link it statically, for targets where a usable
+# system OpenSSL is awkward to obtain (musl, some cross-compiles). Implies `native-tls`. Applies to
+# the reqwest client; a ureq-only build gets `native-tls` (system OpenSSL) without vendoring.
+native-tls-vendored = ["native-tls", "reqwest?/native-tls-vendored"]
 rustls = ["reqwest?/rustls", "ureq?/rustls"]
 
 reqwest = ["dep:reqwest"]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 ARCHIVE_FEATURES = archive-tar \
                    archive-zip \
                    compression-tar-gz \
+                   compression-tar-xz \
                    compression-zip-deflate \
                    compression-zip-bzip2 \
                    signatures \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ clients and multiple TLS backends may coexist (reqwest is preferred when both ar
 * `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client, either alongside reqwest or as a drop-in replacement (set `default-features = false` to drop reqwest);
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
+* `native-tls-vendored`: build OpenSSL from source and link it statically (for targets where a usable system OpenSSL is awkward, e.g. musl or some cross-compiles); implies `native-tls`, applies to the reqwest client;
 
 Note that enabling a client with neither TLS feature compiles (plain-`http` release hosts remain
 reachable) but any `https` URL then fails at request time with a transport error; enable `rustls`
@@ -75,7 +76,8 @@ The following are opt-in; activate the one(s) your release files need:
 * `s3-auth`: sign S3 requests (AWS SigV4) for private buckets; implies `s3`;
 * `archive-tar`: support for _tar_ archive format;
 * `archive-zip`: support for _zip_ archive format;
-* `compression-tar-gz`: support for _gzip_ compression;
+* `compression-tar-gz`: support for _gzip_ compression (`.tar.gz`, `.tgz`, plain `.gz`);
+* `compression-tar-xz`: support for _xz_ compression (`.tar.xz`, `.txz`, plain `.xz`); pure-Rust, no C `liblzma` dependency;
 * `compression-zip-deflate`: support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;

--- a/specs/ref-common-config.md
+++ b/specs/ref-common-config.md
@@ -94,9 +94,18 @@ The `@shared` vocabulary (`macros.rs:231-462`):
   the typed `ProgressStyle { template, chars }` newtype (`ProgressStyle::new(template, chars)`).
 - `show_output(bool)` (`macros.rs:358`).
 - `no_confirm(bool)` (`macros.rs:370`).
+- `show_release_notes(bool)` - show the release notes URL (or the body when no URL is available)
+  in the confirmation prompt; default off.
+- `update_strategy(UpdateStrategy)` - `Compatible` (default, prefer the newest semver-compatible
+  release, else newest overall) or `Latest` (always newest, across a major bump).
 - `unattended()` (`macros.rs:378`) - one-call CI/daemon configuration: sets
   `no_confirm(true)` + `show_output(false)`. Without it the default
   (`no_confirm == false`) blocks on stdin waiting for confirmation.
+
+`tag_prefix(impl Into<String>)` is NOT a shared setter: it is defined per-backend on the
+github/gitlab/gitea `UpdateBuilder`s only (the tag-to-version derivation is forge-specific; s3
+parses versions from object keys and the custom backend supplies its own `Release`s). It writes
+`self.common.tag_prefix`, read by each forge's tag parser via `backends::common::strip_tag_prefix`.
 - `request_config_setters!(common.request)` - splices in
   `timeout`, `request_header`, `retries`, `retry_backoff(base, max)`,
   `http_client(Arc<dyn HttpClient>)` (and `http_client_async` under `async`),

--- a/specs/ref-feature-flags.md
+++ b/specs/ref-feature-flags.md
@@ -25,13 +25,15 @@ All features and their wiring (`Cargo.toml:76-106`):
 | `reqwest` | `dep:reqwest` (blocking, json, http2) | an HTTP client | may coexist with `ureq`; `reqwest` is the default-picked client when both are on (`Cargo.toml:86`) |
 | `ureq` | `dep:ureq` (gzip, json, socks-proxy, charset) | an HTTP client | to use `ureq` alone, set `--no-default-features` so `reqwest` (a default) is not pulled (`Cargo.toml:87`) |
 | `native-tls` | `reqwest?/native-tls`, `ureq?/native-tls` | a TLS backend | forwards native-TLS to whichever client is on (`Cargo.toml:83`) |
+| `native-tls-vendored` | `reqwest?/native-tls-vendored` | `native-tls` | builds OpenSSL from source and links it statically; applies to the reqwest client (a ureq-only build gets system `native-tls` without vendoring) |
 | `rustls` | `reqwest?/rustls`, `ureq?/rustls` | a TLS backend | may coexist with `native-tls`; `rustls` wins when both are on (`Cargo.toml:84`) |
 | `async` | `reqwest`, `reqwest?/stream`, `dep:tokio`, `dep:futures-util`, `dep:bytes` | `reqwest` | async update verbs; requires `reqwest` (`Cargo.toml:95`) |
 | `archive-zip` | `zip`, `zipsign-api?/verify-zip` | - | enables zip extraction; wires zip signature verify when `signatures` on (`Cargo.toml:70`) |
 | `archive-tar` | `tar`, `zipsign-api?/verify-tar` | - | enables tar extraction; wires tar signature verify when `signatures` on (`Cargo.toml:73`) |
 | `compression-zip-bzip2` | `zip/bzip2` | `archive-zip` | bzip2 inside zip (`Cargo.toml:71`) |
 | `compression-zip-deflate` | `zip/deflate` | `archive-zip` | deflate inside zip (`Cargo.toml:72`) |
-| `compression-tar-gz` | `flate2`, `either` | `archive-tar` | gzip; selects `Either<File, GzDecoder>` reader type (`Cargo.toml:74`, `lib.rs:665-668`) |
+| `compression-tar-gz` | `flate2` | `archive-tar` | gzip (`.tar.gz`, `.tgz`, plain `.gz`); adds the `Gz` arm to the `ArchiveReader` codec enum |
+| `compression-tar-xz` | `dep:lzma-rs` | `archive-tar` | xz (`.tar.xz`, `.txz`, plain `.xz`); pure-Rust `lzma-rs` (no C `liblzma`); adds `Compression::Xz` and the `Xz` arm to the `ArchiveReader` codec enum |
 | `progress-bar` | `dep:indicatif` | - | terminal progress bar in `Download`; the `progress_callback` byte hook is always-on and not gated (`Cargo.toml:77`) |
 | `signatures` | `dep:zipsign-api` | - | ed25519ph verify; `verify-zip`/`verify-tar` come from the archive features (`Cargo.toml:75`) |
 | `checksums` | `dep:sha2` | - | sha2 checksum verify (`Cargo.toml:76`) |
@@ -46,8 +48,9 @@ Implication notes:
 - `archive-zip` implies `zip`; the `compression-zip-*` features imply
   `archive-zip` and add a codec to the `zip` dep.
 - `archive-tar` implies `tar`; `compression-tar-gz` implies `archive-tar` and
-  adds `flate2` + `either` (gzip is the only `Compression` variant,
-  `lib.rs:582-586`).
+  adds `flate2`; `compression-tar-xz` implies `archive-tar` and adds `lzma-rs`.
+  `Compression` has two variants, `Gz` and `Xz`, each decoded only when its
+  feature is on; the `ArchiveReader` codec enum has one arm per enabled codec.
 - `signatures` only pulls `zipsign-api` (`dep:zipsign-api`). The actual
   `verify-zip` / `verify-tar` sub-features are pulled in by `archive-zip` /
   `archive-tar` via the optional `zipsign-api?/verify-*` syntax, so signature
@@ -75,10 +78,10 @@ The only `compile_error!` guards that remain:
 
 MSRV / edition: `rust-version = "1.85"`, `edition = "2024"` (`Cargo.toml:12-13`).
 
-docs.rs feature set (`Cargo.toml:17-33`): `reqwest`, `native-tls`,
+docs.rs feature set (`Cargo.toml:17-33`): `reqwest`, `ureq`, `native-tls`,
 `archive-zip`, `compression-zip-bzip2`, `compression-zip-deflate`,
-`archive-tar`, `compression-tar-gz`, `progress-bar`, `signatures`, `checksums`,
-`github`, `gitlab`, `gitea`, `s3`, `s3-auth`, `async`. This pins the documented
+`archive-tar`, `compression-tar-gz`, `compression-tar-xz`, `signatures`, `checksums`,
+`s3-auth`, `async`, `progress-bar`, `github`, `gitlab`, `gitea`, `s3`. This pins the documented
 client/TLS pair to `reqwest` + `native-tls` for a stable rendered surface. The same
 `[package.metadata.docs.rs]` block also sets `rustdoc-args = ["--cfg", "docsrs"]`
 (`Cargo.toml:30`), which sets the `docsrs` cfg so the crate enables the nightly
@@ -118,7 +121,7 @@ Feature-gated public items:
 `ArchiveKind` and `Extract` are public unconditionally, but `ArchiveKind` is
 `#[non_exhaustive]` and its `Tar`/`Zip` variants only exist under their archive
 features (`lib.rs:572-580`). `ArchiveKind` implements `Display` (`lib.rs:589`),
-rendering `tar.gz` / `zip` / `tar` / `gz` / `plain`; the `Error::NoSignatures`
+rendering `tar.gz` / `tar.xz` / `zip` / `tar` / `gz` / `xz` / `plain`; the `Error::NoSignatures`
 message uses it instead of the `Debug` form. `detect_archive` returns
 `Error::ArchiveNotEnabled` for an extension whose archive feature is off
 (`lib.rs:600-603,611-614`).

--- a/specs/ref-github-backend.md
+++ b/specs/ref-github-backend.md
@@ -115,8 +115,12 @@ each element:
 - `body` (optional `String`).
 - `assets` (required array, else `Error::MissingAssetField { field: "assets" }`), each parsed
   via asset DTO parsing.
-- `version` is `tag_name` with a single leading `v` stripped via
-  `trim_start_matches('v')`.
+- `version` is derived from `tag_name` via `backends::common::strip_tag_prefix`. With no
+  configured `tag_prefix` this strips a single leading `v` (the default). With a `tag_prefix` set
+  (via the builder's `tag_prefix(..)`), the tag must start with that prefix, which is stripped
+  (plus any leading `v` after it), so a monorepo tag `myapp-1.2.3` yields `1.2.3`; a tag lacking
+  the prefix is skipped from the listing (a `tag_prefix_mismatch_error`, an `Error::SemVer`).
+- `html_url` (optional) maps onto `Release::release_notes_url()`.
 
 Asset DTO parsing requires `url` (download URL, else `Error::MissingAssetField { field: "url" }`)
 and `name` (else `Error::MissingAssetField { field: "name" }`). The optional `digest`
@@ -188,7 +192,9 @@ The setter was renamed `url` -> `api_base_url` (and earlier `with_url` / `instan
   a cross-host asset `download_url` or pagination link does not receive it.
 - List per-page size defaults to 100 and pagination follows `Link: rel="next"`,
   bounded at 100 pages.
-- `version` strips exactly one leading `v` from `tag_name`.
+- `version` strips a single leading `v` from `tag_name` by default; with a configured
+  `tag_prefix`, only tags carrying that prefix are kept (the prefix, plus any inner `v`, is
+  stripped), and non-matching tags are skipped.
 
 ## Tests
 

--- a/specs/ref-release-model.md
+++ b/specs/ref-release-model.md
@@ -33,14 +33,18 @@ and `digest(&self) -> Option<&str>`.
 
 `Release` is a `#[non_exhaustive]` struct deriving `Clone, Debug, Default` with
 **encapsulated** (`pub(crate)`) fields `name: Arc<str>`, `version: Arc<str>`,
-`date: Arc<str>`, `body: Option<Arc<str>>`, and `assets: Vec<ReleaseAsset>`
+`date: Arc<str>`, `body: Option<Arc<str>>`, `release_notes_url: Option<Arc<str>>`,
+and `assets: Vec<ReleaseAsset>`
 (again `Arc<str>`-backed for cheap clones). It is built from outside the crate
 via `Release::builder()`, which returns a `ReleaseBuilder` (the builder stores
 `String`s and converts to `Arc<str>` at `build()`); only `version` is required,
-`name` defaults to the version, `date` defaults to empty, `body` to `None`. The
+`name` defaults to the version, `date` defaults to empty, `body` and
+`release_notes_url` to `None`. The
 fields are read through getters returning borrows: `name(&self) -> &str`,
 `version(&self) -> &str`, `date(&self) -> &str`, `body(&self) -> Option<&str>`,
-and `assets(&self) -> &[ReleaseAsset]`. Callers (in-crate and downstream) read
+`release_notes_url(&self) -> Option<&str>` (the release page URL; the forge
+backends fill it from the release's `html_url`, gitlab from `_links.self`; `None`
+for s3), and `assets(&self) -> &[ReleaseAsset]`. Callers (in-crate and downstream) read
 releases exclusively through these getters; the in-crate construction/write sites
 (the forge DTOs, the s3 parser) go through `Release::builder()` /
 `ReleaseAsset::new` / the crate-private fields.
@@ -221,10 +225,12 @@ with `into_vec()`.
   `with_digest(impl Into<String>)`; getters `name() -> &str`,
   `download_url() -> &str`, `digest() -> Option<&str>`.
 - `pub struct Release` `#[non_exhaustive]` with `pub(crate)` fields (`Arc<str>`
-  `name`/`version`/`date`, `Option<Arc<str>>` `body`, `Vec<ReleaseAsset>`
-  `assets`); `Release::builder()`, `has_target_asset`, `asset_for`; getters
-  `name() -> &str`, `version() -> &str`, `date() -> &str`, `body() -> Option<&str>`,
-  `assets() -> &[ReleaseAsset]`.
+  `name`/`version`/`date`, `Option<Arc<str>>` `body` and `release_notes_url`,
+  `Vec<ReleaseAsset>` `assets`); `Release::builder()`, `has_target_asset`,
+  `asset_for`; getters `name() -> &str`, `version() -> &str`, `date() -> &str`,
+  `body() -> Option<&str>`, `release_notes_url() -> Option<&str>`,
+  `assets() -> &[ReleaseAsset]`. `ReleaseBuilder` has a matching
+  `release_notes_url(impl Into<String>)` setter.
 - `pub struct Releases` `#[non_exhaustive]`; `all`, `len`, `is_empty`,
   `current_version() -> Option<&str>`, `latest`, `into_vec`, `is_update_available`;
   owned and borrowed `IntoIterator`. `Releases::new` is

--- a/specs/ref-signatures-and-checksums.md
+++ b/specs/ref-signatures-and-checksums.md
@@ -91,7 +91,11 @@ from `verify_keys`), stored on the common config's `verifying_keys` field
 `UpdateConfig::verify_keys` (`src/update.rs:710`, `src/macros.rs:260`), which
 defaults to an empty slice.
 
-`verify_signature(archive_path, keys)` (`src/update.rs:933`):
+`verify_signature(archive_path, keys)` (`src/update.rs:933`) is public and
+re-exported at the crate root under `signatures`
+(`self_update::verify_signature`, `src/lib.rs`), so a caller that stages a
+download itself (e.g. an installer fetching a companion binary) can run the same
+check `update()` runs. It takes `impl AsRef<Path>` and a `&[VerifyingKey]` slice:
 - If no keys are supplied it is a no-op returning `Ok(())`
   (`src/update.rs:937`-`939`). Verification only happens when the feature is on
   AND at least one key is provided.
@@ -156,6 +160,9 @@ async flows.
   `signatures` (`src/lib.rs:462`).
 - `verifying_keys(impl Into<Vec<VerifyingKey>>)` builder method
   (`src/macros.rs:617`); the doc-hidden `verify_keys()` accessor keeps its name.
+- `self_update::verify_signature(impl AsRef<Path>, &[VerifyingKey])` free
+  function, re-exported under `signatures` (`src/update.rs`, `src/lib.rs`), for
+  running the signature check standalone (e.g. from an installer).
 - Errors: `Error::ChecksumMismatch { expected, computed }` (checksum mismatch,
   `src/errors.rs:29`), `Error::Signature` (wrapped `ZipsignError`,
   `src/errors.rs:110`), `Error::SignatureNonUTF8` (`src/errors.rs:114`),

--- a/specs/ref-update-pipeline.md
+++ b/specs/ref-update-pipeline.md
@@ -42,8 +42,10 @@ and `update_extended_async`'s future stays `Send` (the `PageRequest::parse` pars
    Otherwise fetch the candidate list via `get_newer_releases()` and run
    `choose_latest_release`, which: filters to releases strictly newer
    than the current version (`bump_is_greater`), sorts them semver-descending so selection is
-   order-independent, prefers the newest semver-*compatible* release, else falls back to the
-   newest available (flagged "*NOT* compatible"), else returns `Ok(None)` => `UpToDate`
+   order-independent, then applies the `update_strategy()`: under `UpdateStrategy::Compatible`
+   (default) it prefers the newest semver-*compatible* release and falls back to the newest
+   available (flagged "*NOT* compatible"); under `UpdateStrategy::Latest` it always takes the
+   newest available, even across a major bump. Empty candidate list => `Ok(None)` => `UpToDate`
    (`update.rs:640-711`). Unparseable versions are dropped by the leading
    `.unwrap_or(false)` filter and never reach the comparator.
 3. `resolve_and_confirm` (`update.rs:716`) selects the asset: a custom `asset_matcher()` closure

--- a/specs/ref-update-pipeline.md
+++ b/specs/ref-update-pipeline.md
@@ -73,12 +73,16 @@ binary path comes from `bin_path_in_archive()` with `{{ version }}`, `{{ target 
 `Extract::from_source(archive).extract_file(tmpdir, bin_path)` (`update.rs:802`). Archive kind
 is detected from the file extension by `detect_archive` (`lib.rs:588`) unless overridden via
 `Extract::archive`: `.zip` => `Zip`; `.tar` => `Tar(None)`; `.tgz` and `.tar.gz` =>
-`Tar(Some(Gz))`; a bare `.gz` => `Plain(Some(Gz))`; anything else => `Plain(None)`. A kind
-whose feature is not enabled yields `Error::ArchiveNotEnabled` (`lib.rs:602`). `ArchiveKind`
-(`lib.rs:574`) and `Compression` (`lib.rs:584`, only `Gz`) are `#[non_exhaustive]`; the `Tar`
-and `Zip` variants are feature-gated on `archive-tar` / `archive-zip`. `Plain` files are
-copied (gz-decoded if `compression-tar-gz`), `Tar` is unpacked via the `tar` crate, `Zip` via
-the `zip` crate (`lib.rs:805-885`). The extracted binary is `<tmpdir>/<bin_path>`
+`Tar(Some(Gz))`; a bare `.gz` => `Plain(Some(Gz))`; `.txz` and `.tar.xz` => `Tar(Some(Xz))`;
+a bare `.xz` => `Plain(Some(Xz))`; anything else => `Plain(None)`. A kind whose archive
+feature is not enabled yields `Error::ArchiveNotEnabled`, and a recognized compression whose
+codec feature is off (a `.gz` without `compression-tar-gz`, a `.xz` without
+`compression-tar-xz`) yields `Error::CompressionNotEnabled` rather than installing the still
+-compressed bytes (`lib.rs:602`). `ArchiveKind` (`lib.rs:574`) and `Compression` (`Gz`, `Xz`)
+are `#[non_exhaustive]`; the `Tar` and `Zip` variants are feature-gated on `archive-tar` /
+`archive-zip`. `Plain` files are copied (gz/xz-decoded when the matching codec feature is on),
+`Tar` is unpacked via the `tar` crate over the decoded stream, `Zip` via the `zip` crate
+(`lib.rs:805-885`). The extracted binary is `<tmpdir>/<bin_path>`
 (`update.rs:803`).
 
 ### Verify ordering
@@ -181,7 +185,8 @@ via `into_version_status`.
   arguments take `impl AsRef<Path>` (as do `Move` / `MoveAll`), with no lifetime
   parameter on the types.
 - `ArchiveKind` (`#[non_exhaustive]`): `Plain(Option<Compression>)`, `Tar(...)` (feature
-  `archive-tar`), `Zip` (feature `archive-zip`). `Compression` (`#[non_exhaustive]`): `Gz`.
+  `archive-tar`), `Zip` (feature `archive-zip`). `Compression` (`#[non_exhaustive]`): `Gz`
+  (feature `compression-tar-gz`), `Xz` (feature `compression-tar-xz`).
 - `Move`: `from_source`, `replace_using_temp`, `to_dest`.
 - `MoveAll` (`#[must_use]`, `#[non_exhaustive]`): `from_temp`, `add`, `commit`.
 

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -413,6 +413,8 @@ pub(crate) struct CommonBuilderConfig {
     pub show_download_progress: bool,
     pub show_output: bool,
     pub no_confirm: bool,
+    pub show_release_notes: bool,
+    pub update_strategy: crate::update::UpdateStrategy,
     pub current_version: Option<String>,
     pub release_tag: Option<String>,
     #[cfg(feature = "progress-bar")]
@@ -449,6 +451,8 @@ impl Default for CommonBuilderConfig {
             show_download_progress: false,
             show_output: true,
             no_confirm: false,
+            show_release_notes: false,
+            update_strategy: crate::update::UpdateStrategy::default(),
             current_version: None,
             release_tag: None,
             #[cfg(feature = "progress-bar")]
@@ -514,6 +518,8 @@ impl CommonBuilderConfig {
             show_download_progress: self.show_download_progress,
             show_output: self.show_output,
             no_confirm: self.no_confirm,
+            show_release_notes: self.show_release_notes,
+            update_strategy: self.update_strategy,
             #[cfg(feature = "progress-bar")]
             progress_template: self.progress_template.clone(),
             #[cfg(feature = "progress-bar")]
@@ -545,6 +551,8 @@ pub(crate) struct CommonConfig {
     pub show_download_progress: bool,
     pub show_output: bool,
     pub no_confirm: bool,
+    pub show_release_notes: bool,
+    pub update_strategy: crate::update::UpdateStrategy,
     #[cfg(feature = "progress-bar")]
     pub progress_template: String,
     #[cfg(feature = "progress-bar")]
@@ -705,6 +713,32 @@ mod tests {
         let built = cfg.build().expect("all required fields present");
         assert_eq!(built.current_version, "0.1.0");
         assert_eq!(built.bin_name, "app");
+    }
+
+    #[test]
+    fn build_defaults_and_propagates_update_strategy() {
+        // Default is `Compatible`; an explicit `Latest` is carried into the resolved config.
+        let base = CommonBuilderConfig {
+            current_version: Some("0.1.0".to_string()),
+            bin_name: Some("app".to_string()),
+            bin_path_in_archive: Some("app".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            base.clone().build().unwrap().update_strategy,
+            crate::update::UpdateStrategy::Compatible,
+            "the default update strategy must be Compatible"
+        );
+
+        let latest = CommonBuilderConfig {
+            update_strategy: crate::update::UpdateStrategy::Latest,
+            ..base
+        };
+        assert_eq!(
+            latest.build().unwrap().update_strategy,
+            crate::update::UpdateStrategy::Latest,
+            "an explicit Latest strategy must be carried into the resolved config"
+        );
     }
 
     #[test]

--- a/src/backends/common.rs
+++ b/src/backends/common.rs
@@ -102,6 +102,41 @@ pub(crate) fn name_tag_in_semver_error(tag: &str, err: Error) -> Error {
     }
 }
 
+/// Strip the configured tag prefix (or the conventional leading `v`) from a release tag to get the
+/// bare version candidate.
+///
+/// With `prefix = None`, a single leading lowercase `v` is trimmed (the long-standing default) and
+/// the result is always `Some`. With `prefix = Some(p)`, the tag must start with `p`; `p` is
+/// stripped and a leading `v` after it is also trimmed (so `myapp-v1.2.3` and `myapp-1.2.3` both
+/// yield `Some("1.2.3")`). A tag that does not start with `p` yields `None`, so the caller skips it:
+/// with a prefix configured, only tags carrying it count as releases (a bare `1.0.0` tag is not
+/// silently accepted just because its remainder parses as semver).
+#[cfg_attr(
+    not(any(feature = "github", feature = "gitlab", feature = "gitea")),
+    allow(dead_code)
+)]
+pub(crate) fn strip_tag_prefix(tag: &str, prefix: Option<&str>) -> Option<String> {
+    match prefix {
+        None => Some(tag.trim_start_matches('v').to_owned()),
+        Some(p) => tag
+            .strip_prefix(p)
+            .map(|rest| rest.trim_start_matches('v').to_owned()),
+    }
+}
+
+/// Build the skippable [`Error::SemVer`] returned when a tag does not carry the configured
+/// `tag_prefix`. It uses the `SemVer` variant so the forge listing walk drops the release (its skip
+/// arm keys on `Error::SemVer`), the same way it drops a non-semver tag.
+#[cfg_attr(
+    not(any(feature = "github", feature = "gitlab", feature = "gitea")),
+    allow(dead_code)
+)]
+pub(crate) fn tag_prefix_mismatch_error(tag: &str, prefix: &str) -> Error {
+    Error::SemVer(Box::new(crate::errors::MessageError(format!(
+        "release tag `{tag}` does not start with the configured tag_prefix `{prefix}`"
+    ))))
+}
+
 /// The lowercased host of a URL, for auth-origin comparison. Parses with `http::Uri` (always
 /// available, no `url` crate needed). Returns `None` when the URL has no host.
 #[cfg_attr(
@@ -415,6 +450,10 @@ pub(crate) struct CommonBuilderConfig {
     pub no_confirm: bool,
     pub show_release_notes: bool,
     pub update_strategy: crate::update::UpdateStrategy,
+    /// Optional tag prefix used to derive the version from a release tag (e.g. `myapp-` for a
+    /// monorepo tag `myapp-1.2.3`). `None` keeps the default of trimming a leading `v`. Only the
+    /// forge backends (github/gitlab/gitea) consult it; set via their `tag_prefix` setter.
+    pub tag_prefix: Option<String>,
     pub current_version: Option<String>,
     pub release_tag: Option<String>,
     #[cfg(feature = "progress-bar")]
@@ -453,6 +492,7 @@ impl Default for CommonBuilderConfig {
             no_confirm: false,
             show_release_notes: false,
             update_strategy: crate::update::UpdateStrategy::default(),
+            tag_prefix: None,
             current_version: None,
             release_tag: None,
             #[cfg(feature = "progress-bar")]
@@ -501,6 +541,7 @@ impl CommonBuilderConfig {
                 field: "current_version",
             })?,
             release_tag: self.release_tag.clone(),
+            tag_prefix: self.tag_prefix.clone(),
             bin_name: self
                 .bin_name
                 .clone()
@@ -545,6 +586,7 @@ pub(crate) struct CommonConfig {
     pub asset_identifier: Option<String>,
     pub current_version: String,
     pub release_tag: Option<String>,
+    pub tag_prefix: Option<String>,
     pub bin_name: String,
     pub bin_install_path: PathBuf,
     pub bin_path_in_archive: String,

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -40,6 +40,7 @@ struct ReleaseDto {
     created_at: Option<String>,
     name: Option<String>,
     body: Option<String>,
+    html_url: Option<String>,
     assets: Option<Vec<AssetDto>>,
 }
 
@@ -67,6 +68,9 @@ impl ReleaseDto {
             .assets(assets);
         if let Some(body) = self.body {
             builder.body(body);
+        }
+        if let Some(url) = self.html_url {
+            builder.release_notes_url(url);
         }
         builder
             .build()

--- a/src/backends/gitea.rs
+++ b/src/backends/gitea.rs
@@ -45,7 +45,7 @@ struct ReleaseDto {
 }
 
 impl ReleaseDto {
-    fn into_release(self) -> Result<Release> {
+    fn into_release(self, tag_prefix: Option<&str>) -> Result<Release> {
         let tag = self
             .tag_name
             .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
@@ -60,10 +60,17 @@ impl ReleaseDto {
             .into_iter()
             .map(AssetDto::into_asset)
             .collect::<Result<Vec<ReleaseAsset>>>()?;
+        let version =
+            crate::backends::common::strip_tag_prefix(&tag, tag_prefix).ok_or_else(|| {
+                crate::backends::common::tag_prefix_mismatch_error(
+                    &tag,
+                    tag_prefix.unwrap_or_default(),
+                )
+            })?;
         let mut builder = Release::builder();
         builder
             .name(name)
-            .version(tag.trim_start_matches('v').to_owned())
+            .version(version)
             .date(date)
             .assets(assets);
         if let Some(body) = self.body {
@@ -222,7 +229,7 @@ impl ReleaseList {
         );
 
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
+        let releases = run_paginated(releases_plan(&api_url, None, None)?, &self.request)?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -244,9 +251,11 @@ impl ReleaseList {
         );
 
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases =
-            crate::backends::run_paginated_async(releases_plan(&api_url, None)?, &self.request)
-                .await?;
+        let releases = crate::backends::run_paginated_async(
+            releases_plan(&api_url, None, None)?,
+            &self.request,
+        )
+        .await?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -303,6 +312,15 @@ impl UpdateBuilder {
     /// Required. Set the repo name, used to build a gitea api url
     pub fn repo_name(&mut self, name: impl Into<String>) -> &mut Self {
         self.repo_name = Some(name.into());
+        self
+    }
+
+    /// Set the tag prefix used to derive a release version from its tag. Defaults to unset, which
+    /// trims a leading `v` (so `v1.2.3` and `1.2.3` both yield `1.2.3`). Set it to, e.g., `myapp-`
+    /// for a monorepo whose tags look like `myapp-1.2.3` (or `myapp-v1.2.3`); tags without the
+    /// prefix are then skipped from the listing rather than mis-parsed.
+    pub fn tag_prefix(&mut self, prefix: impl Into<String>) -> &mut Self {
+        self.common.tag_prefix = Some(prefix.into());
         self
     }
 
@@ -399,7 +417,10 @@ impl Update {
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated(newest_plan(&self.releases_url())?, &self.common.request)?;
+        let releases = run_paginated(
+            newest_plan(&self.releases_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         let release = releases
             .into_iter()
             .next()
@@ -410,14 +431,21 @@ impl ReleaseUpdate for Update {
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )?;
         Ok(Releases::new(releases, current_version))
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        let releases = run_paginated(single_plan(self.tag_url(ver))?, &self.common.request)?;
+        let releases = run_paginated(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         releases
             .into_iter()
             .next()
@@ -455,13 +483,18 @@ impl_update_config_accessors!(Update, {
 /// regardless (a backport release -- older semver, newer creation date -- must not halt the walk
 /// and cause a genuinely newer release on a later page to be missed). When `None` the listing is
 /// unfiltered and every page is walked (used by `ReleaseList`).
-fn releases_plan(base_url: &str, stop_at: Option<&str>) -> Result<PageRequest<Release>> {
+fn releases_plan(
+    base_url: &str,
+    stop_at: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
         first_page_url(base_url),
         headers,
         stop_at,
+        tag_prefix.map(str::to_owned),
     ))
 }
 
@@ -469,6 +502,7 @@ fn release_array_page(
     url: String,
     headers: HeaderMap,
     stop_at: Option<String>,
+    tag_prefix: Option<String>,
 ) -> PageRequest<Release> {
     PageRequest {
         url,
@@ -482,7 +516,7 @@ fn release_array_page(
                 })?;
             let mut items = Vec::new();
             for dto in dtos {
-                let release = match dto.into_release() {
+                let release = match dto.into_release(tag_prefix.as_deref()) {
                     Ok(release) => release,
                     // A non-semver tag (`nightly`, `latest`, a date tag) is not a release the
                     // updater can compare; skip it rather than failing the whole listing, so a
@@ -509,6 +543,7 @@ fn release_array_page(
                         next_url,
                         api_headers()?,
                         stop_at.clone(),
+                        tag_prefix.clone(),
                     ))
                 })
                 .transpose()?;
@@ -525,18 +560,19 @@ fn release_array_page(
 /// first element (newest-first order) is "latest". Fetches just the first page (no pagination).
 /// Entries with non-semver rolling tags (`nightly`, ...) are skipped like the full listing does,
 /// so "newest" is the first entry the updater can actually compare.
-fn newest_plan(base_url: &str) -> Result<PageRequest<Release>> {
+fn newest_plan(base_url: &str, tag_prefix: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
+    let tag_prefix = tag_prefix.map(str::to_owned);
     Ok(PageRequest {
         url: first_page_url(base_url),
         headers,
-        parse: Box::new(|body, _resp_headers| {
+        parse: Box::new(move |body, _resp_headers| {
             let dtos: Vec<ReleaseDto> =
                 serde_json::from_slice(body).map_err(|e| Error::InvalidResponse {
                     source: Box::new(e),
                 })?;
             for dto in dtos {
-                match dto.into_release() {
+                match dto.into_release(tag_prefix.as_deref()) {
                     Ok(release) => return Ok(Page::last(vec![release])),
                     Err(e @ Error::SemVer(_)) => {
                         log::debug!("self_update: skipping listed release: {e}");
@@ -550,16 +586,17 @@ fn newest_plan(base_url: &str) -> Result<PageRequest<Release>> {
 }
 
 /// Transport-free plan to fetch a single release *object* (the `.../releases/tags/{ver}` endpoint).
-fn single_plan(url: String) -> Result<PageRequest<Release>> {
+fn single_plan(url: String, tag_prefix: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
+    let tag_prefix = tag_prefix.map(str::to_owned);
     Ok(PageRequest {
         url,
         headers,
-        parse: Box::new(|body, _resp_headers| {
+        parse: Box::new(move |body, _resp_headers| {
             // An unparseable body is `InvalidResponse`, matching the paginated listing parser.
             let dto: ReleaseDto =
                 serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
-            Ok(Page::last(vec![dto.into_release()?]))
+            Ok(Page::last(vec![dto.into_release(tag_prefix.as_deref())?]))
         }),
     })
 }
@@ -569,8 +606,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
     async fn get_latest_release_async(&self) -> Result<Releases> {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases =
-            run_paginated_async(newest_plan(&self.releases_url())?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            newest_plan(&self.releases_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         let release = releases
             .into_iter()
             .next()
@@ -582,7 +622,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated_async(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )
         .await?;
@@ -591,8 +635,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
 
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
         use crate::backends::run_paginated_async;
-        let releases =
-            run_paginated_async(single_plan(self.tag_url(ver))?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         releases
             .into_iter()
             .next()
@@ -626,15 +673,15 @@ mod tests {
         base_url: &str,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
+        crate::backends::run_paginated_async(super::releases_plan(base_url, None, None)?, req).await
     }
 
     // The single-release endpoint (`.../releases/tags/{ver}`) surfaces an unparseable body as
     // `InvalidResponse`, matching the paginated listing parser (previously `Error::Json`).
     #[test]
     fn single_plan_parse_failure_is_invalid_response() {
-        let req =
-            super::single_plan("https://example.test/releases/tags/1.0.0".to_string()).unwrap();
+        let req = super::single_plan("https://example.test/releases/tags/1.0.0".to_string(), None)
+            .unwrap();
         let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
         assert!(
             matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
@@ -650,6 +697,7 @@ mod tests {
             "https://example.test/releases".to_string(),
             crate::http_client::HeaderMap::new(),
             None,
+            None,
         );
         let body = releases_json(&["nightly", "v1.2.3", "v1.0.0"]);
         let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
@@ -661,11 +709,31 @@ mod tests {
         );
     }
 
+    // A configured `tag_prefix` derives the version from monorepo-style tags (`myapp-1.2.3`,
+    // `myapp-v1.3.0`); tags without the prefix are skipped rather than mis-parsed.
+    #[test]
+    fn listing_with_tag_prefix_parses_prefixed_tags_and_skips_others() {
+        let req = super::release_array_page(
+            "https://example.test/releases".to_string(),
+            crate::http_client::HeaderMap::new(),
+            None,
+            Some("myapp-".to_string()),
+        );
+        let body = releases_json(&["myapp-1.2.3", "otherapp-2.0.0", "myapp-v1.3.0", "1.0.0"]);
+        let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
+        let versions: Vec<&str> = page.items.iter().map(|r| r.version()).collect();
+        assert_eq!(
+            versions,
+            vec!["1.2.3", "1.3.0"],
+            "only `myapp-`-prefixed tags are parsed (with an optional inner `v`); the rest are skipped"
+        );
+    }
+
     // Gitea's "latest" is the listing's first entry; a rolling tag in that slot must be
     // skipped so "newest" is the first release the updater can actually compare.
     #[test]
     fn newest_plan_skips_non_semver_tags() {
-        let req = super::newest_plan("https://example.test/releases").unwrap();
+        let req = super::newest_plan("https://example.test/releases", None).unwrap();
         let body = releases_json(&["nightly", "v1.2.3", "v1.0.0"]);
         let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
         let versions: Vec<&str> = page.items.iter().map(|r| r.version()).collect();
@@ -675,7 +743,7 @@ mod tests {
     // With only non-semver tags there is nothing the updater can compare: NoReleaseFound.
     #[test]
     fn newest_plan_with_only_non_semver_tags_is_no_release_found() {
-        let req = super::newest_plan("https://example.test/releases").unwrap();
+        let req = super::newest_plan("https://example.test/releases", None).unwrap();
         let body = releases_json(&["nightly", "latest"]);
         let res = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new());
         assert!(
@@ -690,8 +758,11 @@ mod tests {
     // The single-release endpoint cannot skip: a pinned non-semver tag errors, naming the tag.
     #[test]
     fn single_plan_non_semver_tag_errors_naming_the_tag() {
-        let req =
-            super::single_plan("https://example.test/releases/tags/nightly".to_string()).unwrap();
+        let req = super::single_plan(
+            "https://example.test/releases/tags/nightly".to_string(),
+            None,
+        )
+        .unwrap();
         let res = (req.parse)(
             release_obj_json("nightly").as_bytes(),
             &crate::http_client::HeaderMap::new(),

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -46,6 +46,7 @@ struct ReleaseDto {
     created_at: Option<String>,
     name: Option<String>,
     body: Option<String>,
+    html_url: Option<String>,
     assets: Option<Vec<AssetDto>>,
 }
 
@@ -73,6 +74,9 @@ impl ReleaseDto {
             .assets(assets);
         if let Some(body) = self.body {
             builder.body(body);
+        }
+        if let Some(url) = self.html_url {
+            builder.release_notes_url(url);
         }
         builder
             .build()
@@ -827,6 +831,28 @@ mod tests {
             .collect::<Vec<_>>()
             .join(",");
         format!("[{objs}]")
+    }
+
+    // A release carrying `html_url` populates `Release::release_notes_url`; a release without it
+    // leaves the URL `None`.
+    #[test]
+    fn release_dto_populates_release_notes_url_from_html_url() {
+        let with_url: super::ReleaseDto = serde_json::from_str(
+            r#"{"tag_name":"v1.2.3","created_at":"2020-01-01T00:00:00Z","name":"v1.2.3",
+                "html_url":"https://github.com/o/r/releases/tag/v1.2.3","assets":[]}"#,
+        )
+        .unwrap();
+        let release = with_url.into_release().unwrap();
+        assert_eq!(
+            release.release_notes_url(),
+            Some("https://github.com/o/r/releases/tag/v1.2.3")
+        );
+
+        let without: super::ReleaseDto = serde_json::from_str(
+            r#"{"tag_name":"v1.2.3","created_at":"2020-01-01T00:00:00Z","name":"v1.2.3","assets":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(without.into_release().unwrap().release_notes_url(), None);
     }
 
     // --- git release-scan early-stop (selection parity + page-2 never requested) -------

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -51,7 +51,7 @@ struct ReleaseDto {
 }
 
 impl ReleaseDto {
-    fn into_release(self) -> Result<Release> {
+    fn into_release(self, tag_prefix: Option<&str>) -> Result<Release> {
         let tag = self
             .tag_name
             .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
@@ -66,10 +66,17 @@ impl ReleaseDto {
             .into_iter()
             .map(AssetDto::into_asset)
             .collect::<Result<Vec<ReleaseAsset>>>()?;
+        let version =
+            crate::backends::common::strip_tag_prefix(&tag, tag_prefix).ok_or_else(|| {
+                crate::backends::common::tag_prefix_mismatch_error(
+                    &tag,
+                    tag_prefix.unwrap_or_default(),
+                )
+            })?;
         let mut builder = Release::builder();
         builder
             .name(name)
-            .version(tag.trim_start_matches('v').to_owned())
+            .version(version)
             .date(date)
             .assets(assets);
         if let Some(body) = self.body {
@@ -214,7 +221,7 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
+        let releases = run_paginated(releases_plan(&api_url, None, None)?, &self.request)?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -237,9 +244,11 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases =
-            crate::backends::run_paginated_async(releases_plan(&api_url, None)?, &self.request)
-                .await?;
+        let releases = crate::backends::run_paginated_async(
+            releases_plan(&api_url, None, None)?,
+            &self.request,
+        )
+        .await?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -287,6 +296,15 @@ impl UpdateBuilder {
     /// for example `https://api.github.com` or `https://github.mycorp.com/api/v3`
     pub fn api_base_url(&mut self, url: impl Into<String>) -> &mut Self {
         self.custom_url = Some(url.into());
+        self
+    }
+
+    /// Set the tag prefix used to derive a release version from its tag. Defaults to unset, which
+    /// trims a leading `v` (so `v1.2.3` and `1.2.3` both yield `1.2.3`). Set it to, e.g., `myapp-`
+    /// for a monorepo whose tags look like `myapp-1.2.3` (or `myapp-v1.2.3`); tags without the
+    /// prefix are then skipped from the listing rather than mis-parsed.
+    pub fn tag_prefix(&mut self, prefix: impl Into<String>) -> &mut Self {
+        self.common.tag_prefix = Some(prefix.into());
         self
     }
 
@@ -409,7 +427,10 @@ impl Update {
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated(single_plan(self.latest_url())?, &self.common.request)?;
+        let releases = run_paginated(
+            single_plan(self.latest_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         let release = releases
             .into_iter()
             .next()
@@ -420,14 +441,21 @@ impl ReleaseUpdate for Update {
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )?;
         Ok(Releases::new(releases, current_version))
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        let releases = run_paginated(single_plan(self.tag_url(ver))?, &self.common.request)?;
+        let releases = run_paginated(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         releases
             .into_iter()
             .next()
@@ -464,13 +492,18 @@ impl_update_config_accessors!(Update, {
 /// regardless (a backport release — older semver, newer creation date — must not halt the walk
 /// and cause a genuinely newer release on a later page to be missed). When `None` the listing is
 /// unfiltered and every page is walked (used by `ReleaseList`).
-fn releases_plan(base_url: &str, stop_at: Option<&str>) -> Result<PageRequest<Release>> {
+fn releases_plan(
+    base_url: &str,
+    stop_at: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
         first_page_url(base_url),
         headers,
         stop_at,
+        tag_prefix.map(str::to_owned),
     ))
 }
 
@@ -479,6 +512,7 @@ fn release_array_page(
     url: String,
     headers: HeaderMap,
     stop_at: Option<String>,
+    tag_prefix: Option<String>,
 ) -> PageRequest<Release> {
     PageRequest {
         url,
@@ -492,7 +526,7 @@ fn release_array_page(
                 })?;
             let mut items = Vec::new();
             for dto in dtos {
-                let release = match dto.into_release() {
+                let release = match dto.into_release(tag_prefix.as_deref()) {
                     Ok(release) => release,
                     // A non-semver tag (`nightly`, `latest`, a date tag) is not a release the
                     // updater can compare; skip it rather than failing the whole listing, so a
@@ -519,6 +553,7 @@ fn release_array_page(
                         next_url,
                         api_headers()?,
                         stop_at.clone(),
+                        tag_prefix.clone(),
                     ))
                 })
                 .transpose()?;
@@ -533,18 +568,19 @@ fn release_array_page(
 
 /// Transport-free plan to fetch a single release *object* (the `/releases/latest` and
 /// `/releases/tags/{ver}` endpoints), parsed via the private `ReleaseDto` into a one-item page.
-fn single_plan(url: String) -> Result<PageRequest<Release>> {
+fn single_plan(url: String, tag_prefix: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
+    let tag_prefix = tag_prefix.map(str::to_owned);
     Ok(PageRequest {
         url,
         headers,
-        parse: Box::new(|body, _resp_headers| {
+        parse: Box::new(move |body, _resp_headers| {
             // The single-release endpoints return a bare release object; deserialize it directly
             // into the DTO and convert. An unparseable body is `InvalidResponse`, matching the
             // paginated listing parser.
             let dto: ReleaseDto =
                 serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
-            Ok(Page::last(vec![dto.into_release()?]))
+            Ok(Page::last(vec![dto.into_release(tag_prefix.as_deref())?]))
         }),
     })
 }
@@ -554,8 +590,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
     async fn get_latest_release_async(&self) -> Result<Releases> {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases =
-            run_paginated_async(single_plan(self.latest_url())?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            single_plan(self.latest_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         let release = releases
             .into_iter()
             .next()
@@ -567,7 +606,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated_async(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )
         .await?;
@@ -576,8 +619,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
 
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
         use crate::backends::run_paginated_async;
-        let releases =
-            run_paginated_async(single_plan(self.tag_url(ver))?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         releases
             .into_iter()
             .next()
@@ -621,7 +667,8 @@ mod tests {
     // they mapped to `Error::Json`, forcing callers to match two variants for one failure).
     #[test]
     fn single_plan_parse_failure_is_invalid_response() {
-        let req = super::single_plan("https://example.test/releases/latest".to_string()).unwrap();
+        let req =
+            super::single_plan("https://example.test/releases/latest".to_string(), None).unwrap();
         let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
         assert!(
             matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
@@ -634,11 +681,32 @@ mod tests {
     // suffixes are valid semver and must NOT be skipped. A capital-`V` prefix is not trimmed
     // (only lowercase `v` is), so a `V`-tagged release is skipped like any other unparseable
     // tag; this documents the boundary of the trim.
+    // A configured `tag_prefix` derives the version from monorepo-style tags (`myapp-1.2.3`,
+    // `myapp-v1.3.0`); tags without the prefix are skipped rather than mis-parsed.
+    #[test]
+    fn listing_with_tag_prefix_parses_prefixed_tags_and_skips_others() {
+        let req = super::release_array_page(
+            "https://example.test/releases".to_string(),
+            crate::http_client::HeaderMap::new(),
+            None,
+            Some("myapp-".to_string()),
+        );
+        let body = releases_array_json(&["myapp-1.2.3", "otherapp-2.0.0", "myapp-v1.3.0", "1.0.0"]);
+        let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
+        let versions: Vec<&str> = page.items.iter().map(|r| r.version()).collect();
+        assert_eq!(
+            versions,
+            vec!["1.2.3", "1.3.0"],
+            "only `myapp-`-prefixed tags are parsed (with an optional inner `v`); the rest are skipped"
+        );
+    }
+
     #[test]
     fn listing_skips_non_semver_tags() {
         let req = super::release_array_page(
             "https://example.test/releases".to_string(),
             crate::http_client::HeaderMap::new(),
+            None,
             None,
         );
         let body = releases_array_json(&[
@@ -720,6 +788,7 @@ mod tests {
             "https://example.test/releases".to_string(),
             crate::http_client::HeaderMap::new(),
             Some("1.0.0".to_string()),
+            None,
         );
         let body = releases_array_json(&["nightly", "v1.2.3", "v0.9.0"]);
         let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
@@ -731,8 +800,11 @@ mod tests {
     // must name the offending tag rather than surfacing a bare semver parse failure.
     #[test]
     fn single_plan_non_semver_tag_errors_naming_the_tag() {
-        let req =
-            super::single_plan("https://example.test/releases/tags/nightly".to_string()).unwrap();
+        let req = super::single_plan(
+            "https://example.test/releases/tags/nightly".to_string(),
+            None,
+        )
+        .unwrap();
         let res = (req.parse)(
             release_obj_json("nightly").as_bytes(),
             &crate::http_client::HeaderMap::new(),
@@ -755,7 +827,7 @@ mod tests {
         base_url: &str,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated(super::releases_plan(base_url, None)?, req)
+        crate::backends::run_paginated(super::releases_plan(base_url, None, None)?, req)
     }
 
     /// Async test wrapper over `releases_plan` + the async driver. `stop_at = None`.
@@ -764,7 +836,7 @@ mod tests {
         base_url: &str,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
+        crate::backends::run_paginated_async(super::releases_plan(base_url, None, None)?, req).await
     }
 
     struct Resp {
@@ -842,7 +914,7 @@ mod tests {
                 "html_url":"https://github.com/o/r/releases/tag/v1.2.3","assets":[]}"#,
         )
         .unwrap();
-        let release = with_url.into_release().unwrap();
+        let release = with_url.into_release(None).unwrap();
         assert_eq!(
             release.release_notes_url(),
             Some("https://github.com/o/r/releases/tag/v1.2.3")
@@ -852,7 +924,10 @@ mod tests {
             r#"{"tag_name":"v1.2.3","created_at":"2020-01-01T00:00:00Z","name":"v1.2.3","assets":[]}"#,
         )
         .unwrap();
-        assert_eq!(without.into_release().unwrap().release_notes_url(), None);
+        assert_eq!(
+            without.into_release(None).unwrap().release_notes_url(),
+            None
+        );
     }
 
     // --- git release-scan early-stop (selection parity + page-2 never requested) -------

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -46,8 +46,18 @@ struct ReleaseDto {
     created_at: Option<String>,
     name: Option<String>,
     description: Option<String>,
+    #[serde(rename = "_links", default)]
+    links: LinksDto,
     #[serde(default)]
     assets: AssetsDto,
+}
+
+/// GitLab release `_links` object; `self` points at the release page (used as the release-notes
+/// URL). Only the `self` link is read.
+#[derive(Deserialize, Default)]
+struct LinksDto {
+    #[serde(rename = "self")]
+    self_url: Option<String>,
 }
 
 impl ReleaseDto {
@@ -75,6 +85,9 @@ impl ReleaseDto {
             .assets(assets);
         if let Some(body) = self.description {
             builder.body(body);
+        }
+        if let Some(url) = self.links.self_url {
+            builder.release_notes_url(url);
         }
         builder
             .build()
@@ -789,6 +802,29 @@ mod tests {
         format!(
             r#"[{{"tag_name":"{tag}","created_at":"2020-01-01T00:00:00Z","name":"{tag}","assets":{{"links":[]}},"description":null}}]"#
         )
+    }
+
+    // GitLab's release page URL is `_links.self`; it must populate `Release::release_notes_url`.
+    // A release with no `_links` leaves the URL `None`.
+    #[test]
+    fn release_dto_populates_release_notes_url_from_links_self() {
+        let with_url: super::ReleaseDto = serde_json::from_str(
+            r#"{"tag_name":"v1.2.3","created_at":"2020-01-01T00:00:00Z","name":"v1.2.3",
+                "assets":{"links":[]},"description":null,
+                "_links":{"self":"https://gitlab.com/g/p/-/releases/v1.2.3"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            with_url.into_release().unwrap().release_notes_url(),
+            Some("https://gitlab.com/g/p/-/releases/v1.2.3")
+        );
+
+        let without: super::ReleaseDto = serde_json::from_str(
+            r#"{"tag_name":"v1.2.3","created_at":"2020-01-01T00:00:00Z","name":"v1.2.3",
+                "assets":{"links":[]},"description":null}"#,
+        )
+        .unwrap();
+        assert_eq!(without.into_release().unwrap().release_notes_url(), None);
     }
 
     /// A GitLab-format releases JSON array containing one release per entry in `tags`.

--- a/src/backends/gitlab.rs
+++ b/src/backends/gitlab.rs
@@ -61,7 +61,7 @@ struct LinksDto {
 }
 
 impl ReleaseDto {
-    fn into_release(self) -> Result<Release> {
+    fn into_release(self, tag_prefix: Option<&str>) -> Result<Release> {
         let tag = self
             .tag_name
             .ok_or_else(|| Error::missing_asset_field("tag_name"))?;
@@ -77,10 +77,17 @@ impl ReleaseDto {
             .into_iter()
             .map(AssetDto::into_asset)
             .collect::<Result<Vec<ReleaseAsset>>>()?;
+        let version =
+            crate::backends::common::strip_tag_prefix(&tag, tag_prefix).ok_or_else(|| {
+                crate::backends::common::tag_prefix_mismatch_error(
+                    &tag,
+                    tag_prefix.unwrap_or_default(),
+                )
+            })?;
         let mut builder = Release::builder();
         builder
             .name(name)
-            .version(tag.trim_start_matches('v').to_owned())
+            .version(version)
             .date(date)
             .assets(assets);
         if let Some(body) = self.description {
@@ -226,7 +233,7 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases = run_paginated(releases_plan(&api_url, None)?, &self.request)?;
+        let releases = run_paginated(releases_plan(&api_url, None, None)?, &self.request)?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -247,9 +254,11 @@ impl ReleaseList {
             urlencoding::encode(&self.repo_name)
         );
         // An unfiltered listing must walk ALL pages: `stop_at = None`.
-        let releases =
-            crate::backends::run_paginated_async(releases_plan(&api_url, None)?, &self.request)
-                .await?;
+        let releases = crate::backends::run_paginated_async(
+            releases_plan(&api_url, None, None)?,
+            &self.request,
+        )
+        .await?;
         let releases = match self.target {
             None => releases,
             Some(ref target) => releases
@@ -304,6 +313,15 @@ impl UpdateBuilder {
     /// Required. Set the repo name, used to build a gitlab api url
     pub fn repo_name(&mut self, name: impl Into<String>) -> &mut Self {
         self.repo_name = Some(name.into());
+        self
+    }
+
+    /// Set the tag prefix used to derive a release version from its tag. Defaults to unset, which
+    /// trims a leading `v` (so `v1.2.3` and `1.2.3` both yield `1.2.3`). Set it to, e.g., `myapp-`
+    /// for a monorepo whose tags look like `myapp-1.2.3` (or `myapp-v1.2.3`); tags without the
+    /// prefix are then skipped from the listing rather than mis-parsed.
+    pub fn tag_prefix(&mut self, prefix: impl Into<String>) -> &mut Self {
+        self.common.tag_prefix = Some(prefix.into());
         self
     }
 
@@ -395,7 +413,10 @@ impl Update {
 impl ReleaseUpdate for Update {
     fn get_latest_release(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases = run_paginated(newest_plan(&self.releases_url())?, &self.common.request)?;
+        let releases = run_paginated(
+            newest_plan(&self.releases_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         let release = releases
             .into_iter()
             .next()
@@ -406,14 +427,21 @@ impl ReleaseUpdate for Update {
     fn get_newer_releases(&self) -> Result<Releases> {
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )?;
         Ok(Releases::new(releases, current_version))
     }
 
     fn get_release_version(&self, ver: &str) -> Result<Release> {
-        let releases = run_paginated(single_plan(self.tag_url(ver))?, &self.common.request)?;
+        let releases = run_paginated(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )?;
         releases
             .into_iter()
             .next()
@@ -457,13 +485,18 @@ impl Default for UpdateBuilder {
 /// via the private `ReleaseDto` and following `Link: rel="next"`. `stop_at` filters per-item
 /// (releases not strictly newer are omitted but pagination continues); when `None` all pages are
 /// walked unfiltered.
-fn releases_plan(base_url: &str, stop_at: Option<&str>) -> Result<PageRequest<Release>> {
+fn releases_plan(
+    base_url: &str,
+    stop_at: Option<&str>,
+    tag_prefix: Option<&str>,
+) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
     let stop_at = stop_at.map(str::to_owned);
     Ok(release_array_page(
         first_page_url(base_url),
         headers,
         stop_at,
+        tag_prefix.map(str::to_owned),
     ))
 }
 
@@ -471,6 +504,7 @@ fn release_array_page(
     url: String,
     headers: HeaderMap,
     stop_at: Option<String>,
+    tag_prefix: Option<String>,
 ) -> PageRequest<Release> {
     PageRequest {
         url,
@@ -484,7 +518,7 @@ fn release_array_page(
                 })?;
             let mut items = Vec::new();
             for dto in dtos {
-                let release = match dto.into_release() {
+                let release = match dto.into_release(tag_prefix.as_deref()) {
                     Ok(release) => release,
                     // A non-semver tag (`nightly`, `latest`, a date tag) is not a release the
                     // updater can compare; skip it rather than failing the whole listing, so a
@@ -511,6 +545,7 @@ fn release_array_page(
                         next_url,
                         api_headers()?,
                         stop_at.clone(),
+                        tag_prefix.clone(),
                     ))
                 })
                 .transpose()?;
@@ -527,18 +562,19 @@ fn release_array_page(
 /// first element (newest-first order) is "latest". Fetches just the first page (no pagination).
 /// Entries with non-semver rolling tags (`nightly`, ...) are skipped like the full listing does,
 /// so "newest" is the first entry the updater can actually compare.
-fn newest_plan(base_url: &str) -> Result<PageRequest<Release>> {
+fn newest_plan(base_url: &str, tag_prefix: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
+    let tag_prefix = tag_prefix.map(str::to_owned);
     Ok(PageRequest {
         url: first_page_url(base_url),
         headers,
-        parse: Box::new(|body, _resp_headers| {
+        parse: Box::new(move |body, _resp_headers| {
             let dtos: Vec<ReleaseDto> =
                 serde_json::from_slice(body).map_err(|e| Error::InvalidResponse {
                     source: Box::new(e),
                 })?;
             for dto in dtos {
-                match dto.into_release() {
+                match dto.into_release(tag_prefix.as_deref()) {
                     Ok(release) => return Ok(Page::last(vec![release])),
                     Err(e @ Error::SemVer(_)) => {
                         log::debug!("self_update: skipping listed release: {e}");
@@ -552,16 +588,17 @@ fn newest_plan(base_url: &str) -> Result<PageRequest<Release>> {
 }
 
 /// Transport-free plan to fetch a single release *object* (the `.../releases/{ver}` endpoint).
-fn single_plan(url: String) -> Result<PageRequest<Release>> {
+fn single_plan(url: String, tag_prefix: Option<&str>) -> Result<PageRequest<Release>> {
     let headers = api_headers()?;
+    let tag_prefix = tag_prefix.map(str::to_owned);
     Ok(PageRequest {
         url,
         headers,
-        parse: Box::new(|body, _resp_headers| {
+        parse: Box::new(move |body, _resp_headers| {
             // An unparseable body is `InvalidResponse`, matching the paginated listing parser.
             let dto: ReleaseDto =
                 serde_json::from_slice(body).map_err(crate::errors::Error::invalid_response)?;
-            Ok(Page::last(vec![dto.into_release()?]))
+            Ok(Page::last(vec![dto.into_release(tag_prefix.as_deref())?]))
         }),
     })
 }
@@ -571,8 +608,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
     async fn get_latest_release_async(&self) -> Result<Releases> {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
-        let releases =
-            run_paginated_async(newest_plan(&self.releases_url())?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            newest_plan(&self.releases_url(), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         let release = releases
             .into_iter()
             .next()
@@ -584,7 +624,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
         use crate::backends::run_paginated_async;
         let current_version = crate::update::UpdateConfig::current_version(self).to_owned();
         let releases = run_paginated_async(
-            releases_plan(&self.releases_url(), Some(&current_version))?,
+            releases_plan(
+                &self.releases_url(),
+                Some(&current_version),
+                self.common.tag_prefix.as_deref(),
+            )?,
             &self.common.request,
         )
         .await?;
@@ -593,8 +637,11 @@ impl crate::update::AsyncReleaseUpdate for Update {
 
     async fn get_release_version_async(&self, ver: &str) -> Result<Release> {
         use crate::backends::run_paginated_async;
-        let releases =
-            run_paginated_async(single_plan(self.tag_url(ver))?, &self.common.request).await?;
+        let releases = run_paginated_async(
+            single_plan(self.tag_url(ver), self.common.tag_prefix.as_deref())?,
+            &self.common.request,
+        )
+        .await?;
         releases
             .into_iter()
             .next()
@@ -627,14 +674,15 @@ mod tests {
         base_url: &str,
         req: &crate::backends::common::RequestConfig,
     ) -> crate::errors::Result<Vec<super::Release>> {
-        crate::backends::run_paginated_async(super::releases_plan(base_url, None)?, req).await
+        crate::backends::run_paginated_async(super::releases_plan(base_url, None, None)?, req).await
     }
 
     // The single-release endpoint (`.../releases/{ver}`) surfaces an unparseable body as
     // `InvalidResponse`, matching the paginated listing parser (previously `Error::Json`).
     #[test]
     fn single_plan_parse_failure_is_invalid_response() {
-        let req = super::single_plan("https://example.test/releases/1.0.0".to_string()).unwrap();
+        let req =
+            super::single_plan("https://example.test/releases/1.0.0".to_string(), None).unwrap();
         let res = (req.parse)(b"not-json", &crate::http_client::HeaderMap::new());
         assert!(
             matches!(res, Err(crate::errors::Error::InvalidResponse { .. })),
@@ -650,6 +698,7 @@ mod tests {
             "https://example.test/releases".to_string(),
             crate::http_client::HeaderMap::new(),
             None,
+            None,
         );
         let body = releases_json(&["nightly", "v1.2.3", "v1.0.0"]);
         let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
@@ -661,11 +710,31 @@ mod tests {
         );
     }
 
+    // A configured `tag_prefix` derives the version from monorepo-style tags (`myapp-1.2.3`,
+    // `myapp-v1.3.0`); tags without the prefix are skipped rather than mis-parsed.
+    #[test]
+    fn listing_with_tag_prefix_parses_prefixed_tags_and_skips_others() {
+        let req = super::release_array_page(
+            "https://example.test/releases".to_string(),
+            crate::http_client::HeaderMap::new(),
+            None,
+            Some("myapp-".to_string()),
+        );
+        let body = releases_json(&["myapp-1.2.3", "otherapp-2.0.0", "myapp-v1.3.0", "1.0.0"]);
+        let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
+        let versions: Vec<&str> = page.items.iter().map(|r| r.version()).collect();
+        assert_eq!(
+            versions,
+            vec!["1.2.3", "1.3.0"],
+            "only `myapp-`-prefixed tags are parsed (with an optional inner `v`); the rest are skipped"
+        );
+    }
+
     // GitLab's "latest" is the listing's first entry; a rolling tag in that slot must be
     // skipped so "newest" is the first release the updater can actually compare.
     #[test]
     fn newest_plan_skips_non_semver_tags() {
-        let req = super::newest_plan("https://example.test/releases").unwrap();
+        let req = super::newest_plan("https://example.test/releases", None).unwrap();
         let body = releases_json(&["nightly", "v1.2.3", "v1.0.0"]);
         let page = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new()).unwrap();
         let versions: Vec<&str> = page.items.iter().map(|r| r.version()).collect();
@@ -675,7 +744,7 @@ mod tests {
     // With only non-semver tags there is nothing the updater can compare: NoReleaseFound.
     #[test]
     fn newest_plan_with_only_non_semver_tags_is_no_release_found() {
-        let req = super::newest_plan("https://example.test/releases").unwrap();
+        let req = super::newest_plan("https://example.test/releases", None).unwrap();
         let body = releases_json(&["nightly", "latest"]);
         let res = (req.parse)(body.as_bytes(), &crate::http_client::HeaderMap::new());
         assert!(
@@ -690,7 +759,8 @@ mod tests {
     // The single-release endpoint cannot skip: a pinned non-semver tag errors, naming the tag.
     #[test]
     fn single_plan_non_semver_tag_errors_naming_the_tag() {
-        let req = super::single_plan("https://example.test/releases/nightly".to_string()).unwrap();
+        let req =
+            super::single_plan("https://example.test/releases/nightly".to_string(), None).unwrap();
         let res = (req.parse)(
             release_obj_json("nightly").as_bytes(),
             &crate::http_client::HeaderMap::new(),
@@ -815,7 +885,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            with_url.into_release().unwrap().release_notes_url(),
+            with_url.into_release(None).unwrap().release_notes_url(),
             Some("https://gitlab.com/g/p/-/releases/v1.2.3")
         );
 
@@ -824,7 +894,10 @@ mod tests {
                 "assets":{"links":[]},"description":null}"#,
         )
         .unwrap();
-        assert_eq!(without.into_release().unwrap().release_notes_url(), None);
+        assert_eq!(
+            without.into_release(None).unwrap().release_notes_url(),
+            None
+        );
     }
 
     /// A GitLab-format releases JSON array containing one release per entry in `tags`.

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1978,6 +1978,7 @@ mod tests {
             version: "".into(),
             date: "".into(),
             body: None,
+            release_notes_url: None,
             assets: Vec::new(),
         };
         super::add_to_releases_list(&mut releases, empty_name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,7 @@ pub use update::verify_signature;
 pub use update::{AsyncReleaseSource, AsyncReleaseUpdate};
 pub use update::{
     Release, ReleaseAsset, ReleaseBuilder, ReleaseSource, ReleaseStatus, ReleaseUpdate, Releases,
-    UpdateConfig,
+    UpdateConfig, UpdateStrategy,
 };
 #[cfg(feature = "ureq")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ureq")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ clients and multiple TLS backends may coexist (reqwest is preferred when both ar
 * `ureq`: use the [`ureq`](https://docs.rs/ureq) HTTP client, either alongside reqwest or as a drop-in replacement (set `default-features = false` to drop reqwest);
 * `rustls` (default): [pure-Rust TLS](https://github.com/rustls/rustls); does _not_ support 32-bit macOS;
 * `native-tls`: opt-in native/OpenSSL TLS for the selected client;
+* `native-tls-vendored`: build OpenSSL from source and link it statically (for targets where a usable system OpenSSL is awkward, e.g. musl or some cross-compiles); implies `native-tls`, applies to the reqwest client;
 
 Note that enabling a client with neither TLS feature compiles (plain-`http` release hosts remain
 reachable) but any `https` URL then fails at request time with a transport error; enable `rustls`
@@ -74,7 +75,8 @@ The following are opt-in; activate the one(s) your release files need:
 * `s3-auth`: sign S3 requests (AWS SigV4) for private buckets; implies `s3`;
 * `archive-tar`: support for _tar_ archive format;
 * `archive-zip`: support for _zip_ archive format;
-* `compression-tar-gz`: support for _gzip_ compression;
+* `compression-tar-gz`: support for _gzip_ compression (`.tar.gz`, `.tgz`, plain `.gz`);
+* `compression-tar-xz`: support for _xz_ compression (`.tar.xz`, `.txz`, plain `.xz`); pure-Rust, no C `liblzma` dependency;
 * `compression-zip-deflate`: support for _zip_'s _deflate_ compression format;
 * `compression-zip-bzip2`: support for _zip_'s _bzip2_ compression format;
 * `signatures`: use [zipsign](https://github.com/Kijewski/zipsign) to verify `.zip` and `.tar.gz` artifacts. Artifacts are assumed to have been signed using zipsign;
@@ -489,6 +491,9 @@ pub use futures_util;
 #[cfg(feature = "reqwest")]
 #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use reqwest;
+#[cfg(feature = "signatures")]
+#[cfg_attr(docsrs, doc(cfg(feature = "signatures")))]
+pub use update::verify_signature;
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use update::{AsyncReleaseSource, AsyncReleaseUpdate};
@@ -540,8 +545,6 @@ pub use zipsign_api;
 #[cfg_attr(docsrs, doc(cfg(feature = "signatures")))]
 pub type VerifyingKey = [u8; zipsign_api::PUBLIC_KEY_LENGTH];
 
-#[cfg(feature = "compression-tar-gz")]
-use either::Either;
 #[cfg(feature = "progress-bar")]
 use indicatif::{ProgressBar, ProgressStyle as IndicatifProgressStyle};
 use log::debug;
@@ -717,11 +720,11 @@ impl std::fmt::Display for VersionStatus {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum ArchiveKind {
-    /// A tarball, optionally compressed (e.g. `.tar`, `.tar.gz`). Requires `archive-tar`.
+    /// A tarball, optionally compressed (e.g. `.tar`, `.tar.gz`, `.tar.xz`). Requires `archive-tar`.
     #[cfg(feature = "archive-tar")]
     #[cfg_attr(docsrs, doc(cfg(feature = "archive-tar")))]
     Tar(Option<Compression>),
-    /// A bare file, optionally compressed (e.g. a plain binary, or a `.gz` of one).
+    /// A bare file, optionally compressed (e.g. a plain binary, or a `.gz` / `.xz` of one).
     Plain(Option<Compression>),
     /// A zip archive (`.zip`). Requires `archive-zip`.
     #[cfg(feature = "archive-zip")]
@@ -735,8 +738,11 @@ impl std::fmt::Display for ArchiveKind {
             #[cfg(feature = "archive-tar")]
             ArchiveKind::Tar(Some(Compression::Gz)) => write!(f, "tar.gz"),
             #[cfg(feature = "archive-tar")]
+            ArchiveKind::Tar(Some(Compression::Xz)) => write!(f, "tar.xz"),
+            #[cfg(feature = "archive-tar")]
             ArchiveKind::Tar(None) => write!(f, "tar"),
             ArchiveKind::Plain(Some(Compression::Gz)) => write!(f, "gz"),
+            ArchiveKind::Plain(Some(Compression::Xz)) => write!(f, "xz"),
             ArchiveKind::Plain(None) => write!(f, "plain"),
             #[cfg(feature = "archive-zip")]
             ArchiveKind::Zip => write!(f, "zip"),
@@ -744,13 +750,14 @@ impl std::fmt::Display for ArchiveKind {
     }
 }
 
-/// A compression codec applied to an [`ArchiveKind`]. `#[non_exhaustive]`; `Gz` (gzip) is currently
-/// the only variant.
+/// A compression codec applied to an [`ArchiveKind`]. `#[non_exhaustive]`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum Compression {
     /// gzip (`.gz`); decoding the stream requires the `compression-tar-gz` feature.
     Gz,
+    /// xz / LZMA2 (`.xz`); decoding the stream requires the `compression-tar-xz` feature.
+    Xz,
 }
 
 fn detect_archive(path: &path::Path) -> Result<ArchiveKind> {
@@ -830,6 +837,55 @@ fn detect_archive(path: &path::Path) -> Result<ArchiveKind> {
                 }
             }
         },
+        Some(extension) if extension == std::ffi::OsStr::new("txz") => {
+            #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+            {
+                debug!("Detected .txz archive");
+                Ok(ArchiveKind::Tar(Some(Compression::Xz)))
+            }
+            #[cfg(all(feature = "archive-tar", not(feature = "compression-tar-xz")))]
+            {
+                Err(Error::CompressionNotEnabled("xz".to_string()))
+            }
+            #[cfg(not(feature = "archive-tar"))]
+            {
+                Err(Error::ArchiveNotEnabled("tar".to_string()))
+            }
+        }
+        Some(extension) if extension == std::ffi::OsStr::new("xz") => match path
+            .file_stem()
+            .map(path::Path::new)
+            .and_then(|f| f.extension())
+        {
+            Some(extension) if extension == std::ffi::OsStr::new("tar") => {
+                #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+                {
+                    debug!("Detected .tar.xz archive");
+                    Ok(ArchiveKind::Tar(Some(Compression::Xz)))
+                }
+                #[cfg(all(feature = "archive-tar", not(feature = "compression-tar-xz")))]
+                {
+                    Err(Error::CompressionNotEnabled("xz".to_string()))
+                }
+                #[cfg(not(feature = "archive-tar"))]
+                {
+                    Err(Error::ArchiveNotEnabled("tar".to_string()))
+                }
+            }
+            // A plain `.xz` single-file asset: decoding the xz layer requires the
+            // `compression-tar-xz` feature. Without it, refuse rather than installing the still
+            // compressed bytes as the binary.
+            _ => {
+                #[cfg(feature = "compression-tar-xz")]
+                {
+                    Ok(ArchiveKind::Plain(Some(Compression::Xz)))
+                }
+                #[cfg(not(feature = "compression-tar-xz"))]
+                {
+                    Err(Error::CompressionNotEnabled("xz".to_string()))
+                }
+            }
+        },
         _ => Ok(ArchiveKind::Plain(None)),
     };
 
@@ -850,10 +906,32 @@ pub struct Extract {
     source: path::PathBuf,
     archive: Option<ArchiveKind>,
 }
-#[cfg(feature = "compression-tar-gz")]
-type GetArchiveReaderResult = Either<fs::File, flate2::read::GzDecoder<fs::File>>;
-#[cfg(not(feature = "compression-tar-gz"))]
-type GetArchiveReaderResult = fs::File;
+/// A [`Read`](io::Read) over an archive's bytes with any single compression layer (`.gz`, `.xz`)
+/// transparently decoded, so the tar/plain readers above it see the decompressed stream. `Plain`
+/// is the undecoded passthrough. Each compressed variant exists only when its `compression-tar-*`
+/// feature is enabled; [`detect_archive`] rejects a compression whose feature is off before this
+/// is ever built. The gzip layer decodes as a stream; the xz layer is decoded up front into memory
+/// (the `lzma-rs` decoder is one-shot), which is fine for the modestly sized release artifacts this
+/// crate downloads to a temp file.
+enum ArchiveReader {
+    Plain(fs::File),
+    #[cfg(feature = "compression-tar-gz")]
+    Gz(flate2::read::GzDecoder<fs::File>),
+    #[cfg(feature = "compression-tar-xz")]
+    Xz(io::Cursor<Vec<u8>>),
+}
+
+impl io::Read for ArchiveReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            ArchiveReader::Plain(r) => r.read(buf),
+            #[cfg(feature = "compression-tar-gz")]
+            ArchiveReader::Gz(r) => r.read(buf),
+            #[cfg(feature = "compression-tar-xz")]
+            ArchiveReader::Xz(r) => r.read(buf),
+        }
+    }
+}
 
 impl Extract {
     /// Create an `Extract`or from a source path. Accepts anything path-like (`&Path`, `PathBuf`,
@@ -876,14 +954,28 @@ impl Extract {
     fn get_archive_reader(
         source: fs::File,
         compression: Option<Compression>,
-    ) -> GetArchiveReaderResult {
-        #[cfg(feature = "compression-tar-gz")]
+    ) -> Result<ArchiveReader> {
         match compression {
-            Some(Compression::Gz) => Either::Right(flate2::read::GzDecoder::new(source)),
-            None => Either::Left(source),
+            None => Ok(ArchiveReader::Plain(source)),
+            #[cfg(feature = "compression-tar-gz")]
+            Some(Compression::Gz) => Ok(ArchiveReader::Gz(flate2::read::GzDecoder::new(source))),
+            #[cfg(feature = "compression-tar-xz")]
+            Some(Compression::Xz) => {
+                // `lzma-rs` is a one-shot decoder (no streaming `Read` adapter), so decode the
+                // whole `.xz` stream into memory and hand the tar/plain layer a cursor over it.
+                let mut input = io::BufReader::new(source);
+                let mut decoded = Vec::new();
+                lzma_rs::xz_decompress(&mut input, &mut decoded).map_err(|e| Error::Internal {
+                    message: format!("failed to decode xz stream: {e}"),
+                    source: None,
+                })?;
+                Ok(ArchiveReader::Xz(io::Cursor::new(decoded)))
+            }
+            // A compression whose decoder feature is disabled is rejected by `detect_archive`
+            // before extraction, so this is unreachable in practice.
+            #[allow(unreachable_patterns)]
+            Some(_) => Err(Error::CompressionNotEnabled("unsupported".to_string())),
         }
-        #[cfg(not(feature = "compression-tar-gz"))]
-        source
     }
 
     /// Extract an entire source archive into a specified path. If the source is a single compressed
@@ -900,7 +992,7 @@ impl Extract {
         // We cannot use a feature flag in a match arm. To bypass this the code block is
         // isolated in a closure and called accordingly.
         let extract_into_plain_or_tar = |source: fs::File, compression: Option<Compression>| {
-            let mut reader = Self::get_archive_reader(source, compression);
+            let mut reader = Self::get_archive_reader(source, compression)?;
 
             match archive {
                 ArchiveKind::Plain(_) => {
@@ -1016,7 +1108,7 @@ impl Extract {
         // We cannot use a feature flag in a match arm. To bypass this the code block is
         // isolated in a closure and called accordingly.
         let extract_file_plain_or_tar = |source: fs::File, compression: Option<Compression>| {
-            let mut reader = Self::get_archive_reader(source, compression);
+            let mut reader = Self::get_archive_reader(source, compression)?;
 
             match archive {
                 ArchiveKind::Plain(_) => {
@@ -1946,12 +2038,17 @@ mod tests {
     fn archive_kind_display_is_human_readable() {
         assert_eq!(ArchiveKind::Plain(None).to_string(), "plain");
         assert_eq!(ArchiveKind::Plain(Some(Compression::Gz)).to_string(), "gz");
+        assert_eq!(ArchiveKind::Plain(Some(Compression::Xz)).to_string(), "xz");
         #[cfg(feature = "archive-tar")]
         {
             assert_eq!(ArchiveKind::Tar(None).to_string(), "tar");
             assert_eq!(
                 ArchiveKind::Tar(Some(Compression::Gz)).to_string(),
                 "tar.gz"
+            );
+            assert_eq!(
+                ArchiveKind::Tar(Some(Compression::Xz)).to_string(),
+                "tar.xz"
             );
         }
         #[cfg(feature = "archive-zip")]
@@ -2897,6 +2994,54 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "compression-tar-xz")]
+    #[test]
+    fn detect_plain_xz() {
+        assert_eq!(
+            ArchiveKind::Plain(Some(Compression::Xz)),
+            detect_archive(&PathBuf::from("Something.exe.xz")).unwrap()
+        );
+    }
+
+    // Without the xz feature, a plain `.xz` asset must be rejected with `CompressionNotEnabled`
+    // rather than silently installed as still-compressed bytes (the original #143 footgun).
+    #[cfg(not(feature = "compression-tar-xz"))]
+    #[test]
+    fn detect_plain_xz_without_feature_errors() {
+        assert!(matches!(
+            detect_archive(&PathBuf::from("Something.exe.xz")),
+            Err(Error::CompressionNotEnabled(_))
+        ));
+    }
+
+    #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+    #[test]
+    fn detect_tar_xz() {
+        // Both the `.tar.xz` double extension and the `.txz` short form resolve to a gzip-free tar.
+        assert_eq!(
+            ArchiveKind::Tar(Some(Compression::Xz)),
+            detect_archive(&PathBuf::from("Something.tar.xz")).unwrap()
+        );
+        assert_eq!(
+            ArchiveKind::Tar(Some(Compression::Xz)),
+            detect_archive(&PathBuf::from("Something.txz")).unwrap()
+        );
+    }
+
+    // `.tar.xz` / `.txz` with the tar container but no xz codec must error, not fall through.
+    #[cfg(all(feature = "archive-tar", not(feature = "compression-tar-xz")))]
+    #[test]
+    fn detect_tar_xz_without_compression_errors() {
+        assert!(matches!(
+            detect_archive(&PathBuf::from("Something.tar.xz")),
+            Err(Error::CompressionNotEnabled(_))
+        ));
+        assert!(matches!(
+            detect_archive(&PathBuf::from("Something.txz")),
+            Err(Error::CompressionNotEnabled(_))
+        ));
+    }
+
     #[cfg(not(feature = "archive-tar"))]
     #[test]
     #[ignore]
@@ -3060,6 +3205,86 @@ mod tests {
             "self_update_unpack_file_tar_gzip_src",
             "archive.tar.gz",
             ArchiveKind::Tar(Some(Compression::Gz)),
+        );
+    }
+
+    // --- xz (#143) round-trips, mirroring the gzip coverage above -----------------------------
+
+    // A plain single-file `.xz` decodes to the file with the `.xz` extension stripped.
+    #[cfg(feature = "compression-tar-xz")]
+    #[test]
+    fn unpack_plain_xz() {
+        let tmp_dir = tempfile::Builder::new()
+            .prefix("self_update_unpack_plain_xz_src")
+            .tempdir()
+            .expect("tempdir fail");
+        let fp = tmp_dir.path().with_file_name("temp.xz");
+        {
+            let mut tmp_file = File::create(&fp).expect("temp file create fail");
+            lzma_rs::xz_compress(&mut &b"This is a test!"[..], &mut tmp_file)
+                .expect("xz encode fail");
+        }
+
+        let out_tmp = tempfile::Builder::new()
+            .prefix("self_update_unpack_plain_xz_outdir")
+            .tempdir()
+            .expect("tempdir fail");
+        let out_path = out_tmp.path();
+        Extract::from_source(&fp)
+            .extract_into(out_path)
+            .expect("extract fail");
+        let out_file = out_path.join("temp");
+        assert!(out_file.exists());
+        cmp_content(out_file, "This is a test!");
+    }
+
+    // A plain `.xz` extracted via `extract_file` is written under the requested name.
+    #[cfg(feature = "compression-tar-xz")]
+    #[test]
+    fn unpack_file_plain_xz() {
+        let tmp_dir = tempfile::Builder::new()
+            .prefix("self_update_unpack_file_plain_xz_src")
+            .tempdir()
+            .expect("tempdir fail");
+        let fp = tmp_dir.path().with_file_name("temp.xz");
+        {
+            let mut tmp_file = File::create(&fp).expect("temp file create fail");
+            lzma_rs::xz_compress(&mut &b"This is a test!"[..], &mut tmp_file)
+                .expect("xz encode fail");
+        }
+
+        let out_tmp = tempfile::Builder::new()
+            .prefix("self_update_unpack_file_plain_xz_outdir")
+            .tempdir()
+            .expect("tempdir fail");
+        let out_path = out_tmp.path();
+        Extract::from_source(&fp)
+            .extract_file(out_path, "renamed_file")
+            .expect("extract fail");
+        let out_file = out_path.join("renamed_file");
+        assert!(out_file.exists());
+        cmp_content(out_file, "This is a test!");
+    }
+
+    // A `.tar.xz` unpacks its full tree, exercising the streamed tar-over-xz path end to end.
+    #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+    #[test]
+    fn unpack_tar_xz() {
+        test_extract_into(
+            "self_update_unpack_tar_xz_src",
+            "archive.tar.xz",
+            ArchiveKind::Tar(Some(Compression::Xz)),
+        );
+    }
+
+    // A single member of a `.tar.xz` is extractable by path.
+    #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+    #[test]
+    fn unpack_file_tar_xz() {
+        test_extract_file(
+            "self_update_unpack_file_tar_xz_src",
+            "archive.tar.xz",
+            ArchiveKind::Tar(Some(Compression::Xz)),
         );
     }
 
@@ -3254,6 +3479,32 @@ mod tests {
                 io::copy(&mut tar_writer.as_slice(), &mut e)
                     .expect("failed writing from tar archive to gz encoder");
                 e.finish().expect("gz finish fail");
+            }
+
+            #[cfg(all(feature = "archive-tar", feature = "compression-tar-xz"))]
+            ArchiveKind::Tar(Some(Compression::Xz)) => {
+                let tmp_tar_path = archive_file_path
+                    .parent()
+                    .expect("Missing archive file path parent")
+                    .join("tar_contents_xz");
+                let tmp_tar_inner_path = tmp_tar_path.join("inner_archive");
+                fs::create_dir_all(&tmp_tar_inner_path).expect("Failed to create temp tar path");
+
+                let fp = tmp_tar_path.join("temp.txt");
+                let mut tmp_file = File::create(fp).expect("temp file create fail");
+                tmp_file.write_all(b"This is a test!").unwrap();
+
+                let fp = tmp_tar_inner_path.join("temp2.txt");
+                let mut tmp_file = File::create(fp).expect("temp file create fail");
+                tmp_file.write_all(b"This is a second test!").unwrap();
+
+                let mut ar = tar::Builder::new(vec![]);
+                ar.append_dir_all(".", &tmp_tar_path)
+                    .expect("tar append dir all fail");
+                let tar_writer = ar.into_inner().expect("failed getting tar writer");
+
+                lzma_rs::xz_compress(&mut tar_writer.as_slice(), &mut archive_file)
+                    .expect("failed writing from tar archive to xz encoder");
             }
 
             #[cfg(feature = "archive-zip")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -915,8 +915,10 @@ pub struct Extract {
 /// crate downloads to a temp file.
 enum ArchiveReader {
     Plain(fs::File),
+    // Boxed: a `GzDecoder` is far larger than the other variants, so an unboxed variant would bloat
+    // every `ArchiveReader` to its size (clippy::large_enum_variant).
     #[cfg(feature = "compression-tar-gz")]
-    Gz(flate2::read::GzDecoder<fs::File>),
+    Gz(Box<flate2::read::GzDecoder<fs::File>>),
     #[cfg(feature = "compression-tar-xz")]
     Xz(io::Cursor<Vec<u8>>),
 }
@@ -958,7 +960,9 @@ impl Extract {
         match compression {
             None => Ok(ArchiveReader::Plain(source)),
             #[cfg(feature = "compression-tar-gz")]
-            Some(Compression::Gz) => Ok(ArchiveReader::Gz(flate2::read::GzDecoder::new(source))),
+            Some(Compression::Gz) => Ok(ArchiveReader::Gz(Box::new(flate2::read::GzDecoder::new(
+                source,
+            )))),
             #[cfg(feature = "compression-tar-xz")]
             Some(Compression::Xz) => {
                 // `lzma-rs` is a one-shot decoder (no streaming `Read` adapter), so decode the

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -300,6 +300,12 @@ macro_rules! impl_update_config_accessors {
         fn no_confirm(&self) -> bool {
             self.common.no_confirm
         }
+        fn update_strategy(&self) -> crate::update::UpdateStrategy {
+            self.common.update_strategy
+        }
+        fn show_release_notes(&self) -> bool {
+            self.common.show_release_notes
+        }
         #[cfg(feature = "progress-bar")]
         fn progress_template(&self) -> &str {
             &self.common.progress_template
@@ -614,6 +620,28 @@ macro_rules! impl_common_builder_setters {
         /// requires `show_output(false)` as well.
         pub fn no_confirm(&mut self, no_confirm: bool) -> &mut Self {
             self.common.no_confirm = no_confirm;
+            self
+        }
+
+        /// Choose which release the unpinned "latest" path installs when several are newer than the
+        /// current version. Defaults to [`UpdateStrategy::Compatible`](crate::UpdateStrategy::Compatible)
+        /// (prefer the newest semver-compatible release); pass
+        /// [`UpdateStrategy::Latest`](crate::UpdateStrategy::Latest) to always jump to the newest
+        /// release, even across an incompatible (major) bump. No effect when a `release_tag(..)` is
+        /// pinned.
+        pub fn update_strategy(&mut self, strategy: crate::update::UpdateStrategy) -> &mut Self {
+            self.common.update_strategy = strategy;
+            self
+        }
+
+        /// Show the release notes in the confirmation prompt (defaults to `false`). When enabled,
+        /// the release status block includes the release notes URL if the backend provides one
+        /// (github/gitlab/gitea fill it from the release page; see
+        /// [`Release::release_notes_url`](crate::Release::release_notes_url)), otherwise the release
+        /// body if present. No effect when `no_confirm` and `show_output` are both off (nothing is
+        /// printed).
+        pub fn show_release_notes(&mut self, show: bool) -> &mut Self {
+            self.common.show_release_notes = show;
             self
         }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -3532,7 +3532,8 @@ mod tests {
         let signed_file = sign_tar_gz(&unsigned, &[signing_key])?;
 
         // Owned PathBuf argument exercises the `impl AsRef<Path>` signature.
-        crate::verify_signature(signed_file.path().to_path_buf(), &[vkey])?;
+        let owned: std::path::PathBuf = signed_file.path().into();
+        crate::verify_signature(owned, &[vkey])?;
 
         // An empty key slice is a no-op success (nothing to verify against).
         crate::verify_signature(signed_file.path(), &[])

--- a/src/update.rs
+++ b/src/update.rs
@@ -1499,11 +1499,42 @@ fn println(show_output: bool, msg: &str) {
     }
 }
 
+/// Verify a downloaded archive's embedded signature against a set of ed25519 verifying keys, the
+/// same check [`update()`](ReleaseUpdate::update) runs internally when `verifying_keys` are set.
+///
+/// This is exposed so a caller that stages a download itself (for example an installer that fetches
+/// a companion binary via [`Download`](crate::Download) before the main update loop exists) can run
+/// the identical verification without reimplementing it.
+///
+/// `keys` are raw 32-byte ed25519 public keys ([`VerifyingKey`](crate::VerifyingKey)); verification
+/// uses any-of semantics, passing as soon as one key validates a signature in the archive (so a
+/// key-rotation window can list both the old and new keys). Signatures are produced and read with
+/// [`zipsign`](zipsign_api), which supports `.tar.gz` and `.zip` archives only.
+///
+/// # Errors
+///
+/// - Returns `Ok(())` immediately when `keys` is empty (nothing to verify against).
+/// - [`Error::NoSignatures`](crate::errors::Error::NoSignatures) if the archive format is not one
+///   zipsign can carry a signature in (anything other than `.tar.gz` / `.zip`).
+/// - [`Error::Signature`](crate::errors::Error::Signature) if no key validates a signature.
+/// - [`Error::SignatureNonUTF8`](crate::errors::Error::SignatureNonUTF8) if the archive's file name
+///   is not UTF-8 (zipsign binds the signature to the file name).
+/// - [`Error::Io`](crate::errors::Error::Io) if the archive cannot be opened.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// const KEY: self_update::VerifyingKey = *include_bytes!("../release.pub");
+/// self_update::Download::from_url(url).download_to(&mut file)?;
+/// self_update::verify_signature("downloaded-1.2.3.tar.gz", &[KEY])?;
+/// ```
 #[cfg(feature = "signatures")]
-fn verify_signature(
-    archive_path: &std::path::Path,
-    keys: &[[u8; zipsign_api::PUBLIC_KEY_LENGTH]],
+#[cfg_attr(docsrs, doc(cfg(feature = "signatures")))]
+pub fn verify_signature(
+    archive_path: impl AsRef<std::path::Path>,
+    keys: &[crate::VerifyingKey],
 ) -> crate::Result<()> {
+    let archive_path = archive_path.as_ref();
     if keys.is_empty() {
         return Ok(());
     }
@@ -3330,6 +3361,29 @@ mod tests {
         let signed_file = sign_tar_gz(&unsigned, &[signing_key])?;
 
         super::verify_signature(signed_file.path(), &[vkey])
+    }
+
+    /// The public crate-root `self_update::verify_signature` (exposed for callers that stage a
+    /// download themselves, e.g. an installer) verifies a signed archive, accepts a `VerifyingKey`
+    /// slice, and takes `impl AsRef<Path>` (here a `PathBuf`, not just `&Path`).
+    #[test]
+    #[cfg(all(
+        feature = "signatures",
+        feature = "archive-tar",
+        feature = "compression-tar-gz",
+    ))]
+    fn public_verify_signature_reexport_verifies_signed_archive() -> Result<()> {
+        let signing_key = zipsign_api::SigningKey::from_bytes(&[7u8; 32]);
+        let vkey: crate::VerifyingKey = signing_key.verifying_key().to_bytes();
+
+        let unsigned = make_tar_gz()?;
+        let signed_file = sign_tar_gz(&unsigned, &[signing_key])?;
+
+        // Owned PathBuf argument exercises the `impl AsRef<Path>` signature.
+        crate::verify_signature(signed_file.path().to_path_buf(), &[vkey])?;
+
+        // An empty key slice is a no-op success (nothing to verify against).
+        crate::verify_signature(signed_file.path(), &[])
     }
 
     /// An archive dual-signed with two keys verifies independently against each key.

--- a/src/update.rs
+++ b/src/update.rs
@@ -150,6 +150,7 @@ pub struct Release {
     pub(crate) version: Arc<str>,
     pub(crate) date: Arc<str>,
     pub(crate) body: Option<Arc<str>>,
+    pub(crate) release_notes_url: Option<Arc<str>>,
     pub(crate) assets: Vec<ReleaseAsset>,
 }
 
@@ -172,6 +173,14 @@ impl Release {
     /// The release body / notes, if any.
     pub fn body(&self) -> Option<&str> {
         self.body.as_deref()
+    }
+
+    /// A URL to the release notes / release page, if the backend provides one. The forge backends
+    /// (github, gitlab, gitea) fill it from the release's `html_url`; s3 has none. Shown in the
+    /// confirmation prompt when [`show_release_notes(true)`](crate::backends) is set, and readable
+    /// directly for a caller that wants to surface it itself.
+    pub fn release_notes_url(&self) -> Option<&str> {
+        self.release_notes_url.as_deref()
     }
 
     /// The release's downloadable assets.
@@ -238,6 +247,7 @@ pub struct ReleaseBuilder {
     version: Option<String>,
     date: Option<String>,
     body: Option<String>,
+    release_notes_url: Option<String>,
     assets: Vec<ReleaseAsset>,
 }
 
@@ -273,6 +283,13 @@ impl ReleaseBuilder {
         self
     }
 
+    /// Set a URL to the release notes / release page (the forge backends fill this from the
+    /// release's `html_url`). Optional; unset means no notes URL is available.
+    pub fn release_notes_url(&mut self, url: impl Into<String>) -> &mut Self {
+        self.release_notes_url = Some(url.into());
+        self
+    }
+
     /// Add a single downloadable asset.
     pub fn asset(&mut self, asset: ReleaseAsset) -> &mut Self {
         self.assets.push(asset);
@@ -305,6 +322,7 @@ impl ReleaseBuilder {
             version: Arc::from(version),
             date: Arc::from(self.date.clone().unwrap_or_default()),
             body: self.body.clone().map(Arc::from),
+            release_notes_url: self.release_notes_url.clone().map(Arc::from),
             assets: self.assets.clone(),
         })
     }
@@ -738,6 +756,26 @@ pub(crate) mod sealed {
 /// bounded `R: ReleaseUpdate` they are in scope via the supertrait bound (also no import). It is
 /// only needed in scope (`use self_update::UpdateConfig;`) to call an accessor on a concrete
 /// backend `Update` value.
+/// How the "latest" update path chooses which release to install when several are newer than the
+/// current version.
+///
+/// Only affects the unpinned path (`update()` / `update_extended()` with no `release_tag`); a
+/// `release_tag(..)` fetch always installs exactly that tag. Set via `update_strategy(..)` on the
+/// builders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum UpdateStrategy {
+    /// Prefer the newest release that is semver-compatible with the current version (no major
+    /// bump); fall back to the newest release overall when none is compatible. This is the default
+    /// and matches the pre-1.0 behavior: given `1.1.0, 1.1.1, 1.1.2, 2.0.0` from `1.1.1`, it picks
+    /// `1.1.2` (updating to `2.0.0` would take a second invocation once on a `2.x` line).
+    #[default]
+    Compatible,
+    /// Always select the newest release overall, even across an incompatible (major) version bump.
+    /// Given `1.1.0, 1.1.1, 1.1.2, 2.0.0` from `1.1.1`, it picks `2.0.0`.
+    Latest,
+}
+
 pub trait UpdateConfig: sealed::Sealed {
     /// Current version of binary being updated
     fn current_version(&self) -> &str;
@@ -771,6 +809,18 @@ pub trait UpdateConfig: sealed::Sealed {
 
     /// Flag indicating if the user shouldn't be prompted to confirm an update
     fn no_confirm(&self) -> bool;
+
+    /// Strategy for choosing which release the unpinned "latest" path installs (set via
+    /// `update_strategy`). Defaults to [`UpdateStrategy::Compatible`].
+    fn update_strategy(&self) -> UpdateStrategy {
+        UpdateStrategy::Compatible
+    }
+
+    /// Flag indicating whether the release notes URL (or body) should be shown in the confirmation
+    /// prompt (set via `show_release_notes`). Defaults to `false`.
+    fn show_release_notes(&self) -> bool {
+        false
+    }
 
     /// Message template to use if `show_download_progress` is set (see `indicatif::ProgressStyle`)
     #[cfg(feature = "progress-bar")]
@@ -927,7 +977,12 @@ pub trait ReleaseUpdate: UpdateConfig + UpdateInternals {
             None => {
                 print_flush(show_output, "Checking latest released version... ")?;
                 let releases = self.get_newer_releases()?;
-                match choose_latest_release(releases.into_vec(), current_version, show_output)? {
+                match choose_latest_release(
+                    releases.into_vec(),
+                    current_version,
+                    show_output,
+                    self.update_strategy(),
+                )? {
                     Some(release) => release,
                     None => return Ok(ReleaseStatus::UpToDate),
                 }
@@ -973,6 +1028,7 @@ fn choose_latest_release(
     releases: Vec<Release>,
     current_version: &str,
     show_output: bool,
+    strategy: UpdateStrategy,
 ) -> Result<Option<Release>> {
     // Only consider releases strictly newer than the current version. The built-in backends already
     // pre-filter this way, so this is a no-op for them; it matters for `backends::custom`, whose
@@ -989,11 +1045,16 @@ fn choose_latest_release(
     // release comparator (also used by `backends::s3::sort_newer`/`pick_latest`).
     releases.sort_by(|x, y| version::cmp_releases_newest_first(x.version(), y.version()));
 
-    // Filter to versions compatible with the current one.
-    let compatible_releases = releases
-        .iter()
-        .filter(|r| version::bump_is_compatible(current_version, r.version()).unwrap_or(false))
-        .collect::<Vec<_>>();
+    // Under `Latest`, install the newest release overall (ignoring semver compatibility). Under
+    // `Compatible` (default), prefer the newest semver-compatible release and only fall back to the
+    // newest overall when none is compatible.
+    let compatible_releases = match strategy {
+        UpdateStrategy::Latest => Vec::new(),
+        _ => releases
+            .iter()
+            .filter(|r| version::bump_is_compatible(current_version, r.version()).unwrap_or(false))
+            .collect::<Vec<_>>(),
+    };
 
     let release = if let Some(release) = compatible_releases.first() {
         println(
@@ -1058,7 +1119,7 @@ pub(crate) mod testing {
         releases: Vec<Release>,
         current_version: &str,
     ) -> Result<Option<Release>> {
-        choose_latest_release(releases, current_version, false)
+        choose_latest_release(releases, current_version, false, UpdateStrategy::Compatible)
     }
 
     /// Construct a [`Release`] with a raw (possibly non-semver) version string, bypassing
@@ -1071,6 +1132,7 @@ pub(crate) mod testing {
             version: Arc::from(version),
             date: Arc::from(""),
             body: None,
+            release_notes_url: None,
             assets: Vec::new(),
         }
     }
@@ -1143,6 +1205,13 @@ fn resolve_and_confirm<U: UpdateConfig + UpdateInternals + ?Sized>(
             "  * New exe download url: {:?}",
             crate::errors::redact_url(target_asset.download_url())
         );
+        if u.show_release_notes() {
+            if let Some(url) = release.release_notes_url() {
+                println!("  * Release notes: {}", url);
+            } else if let Some(body) = release.body() {
+                println!("  * Release notes:\n{}", body);
+            }
+        }
         println!(
             "\nThe new release will be downloaded/extracted and the existing binary will be replaced."
         );
@@ -1406,7 +1475,12 @@ where
         None => {
             print_flush(show_output, "Checking latest released version... ")?;
             let releases = u.get_newer_releases_async().await?;
-            match choose_latest_release(releases.into_vec(), current_version, show_output)? {
+            match choose_latest_release(
+                releases.into_vec(),
+                current_version,
+                show_output,
+                u.update_strategy(),
+            )? {
                 Some(release) => release,
                 None => return Ok(ReleaseStatus::UpToDate),
             }
@@ -1575,7 +1649,7 @@ pub fn verify_signature(
 
 #[cfg(test)]
 mod tests {
-    use super::{ReleaseAsset, Releases, choose_latest_release, install_binary};
+    use super::{ReleaseAsset, Releases, UpdateStrategy, choose_latest_release, install_binary};
     use crate::Download;
     use crate::DynVerifyFn;
     use crate::errors::Result;
@@ -1712,6 +1786,23 @@ mod tests {
         let b = Release::builder().version("1.2.3").build().unwrap();
         assert_eq!(a.version(), b.version());
         assert_eq!(a.name(), b.name());
+    }
+
+    #[test]
+    fn release_builder_release_notes_url_roundtrips() {
+        // Set via the builder, read via the getter; unset stays None.
+        let with_url = Release::builder()
+            .version("1.2.3")
+            .release_notes_url("https://example.com/releases/v1.2.3")
+            .build()
+            .unwrap();
+        assert_eq!(
+            with_url.release_notes_url(),
+            Some("https://example.com/releases/v1.2.3")
+        );
+
+        let without = Release::builder().version("1.2.3").build().unwrap();
+        assert_eq!(without.release_notes_url(), None);
     }
 
     #[test]
@@ -2199,15 +2290,20 @@ mod tests {
     fn choose_latest_release_up_to_date_when_nothing_newer() {
         // No releases at all.
         assert!(
-            choose_latest_release(vec![], "1.0.0", false)
+            choose_latest_release(vec![], "1.0.0", false, UpdateStrategy::Compatible)
                 .unwrap()
                 .is_none()
         );
 
         // A source (e.g. a custom backend) that returns the current and older versions must be
         // treated as up-to-date — not re-install the current version. (Regression test.)
-        let chosen =
-            choose_latest_release(vec![rel("1.0.0"), rel("0.9.0")], "1.0.0", false).unwrap();
+        let chosen = choose_latest_release(
+            vec![rel("1.0.0"), rel("0.9.0")],
+            "1.0.0",
+            false,
+            UpdateStrategy::Compatible,
+        )
+        .unwrap();
         assert!(
             chosen.is_none(),
             "current/older releases must not be offered as an update"
@@ -2220,6 +2316,7 @@ mod tests {
             vec![rel("1.2.0"), rel("1.1.0"), rel("1.0.0")],
             "1.0.0",
             false,
+            UpdateStrategy::Compatible,
         )
         .unwrap()
         .expect("a compatible newer release is chosen");
@@ -2234,6 +2331,7 @@ mod tests {
             vec![rel("1.1.0"), rel("1.4.2"), rel("1.0.5"), rel("1.3.0")],
             "1.0.0",
             false,
+            UpdateStrategy::Compatible,
         )
         .unwrap()
         .expect("the newest compatible release is chosen regardless of input order");
@@ -2244,6 +2342,7 @@ mod tests {
             vec![rel("1.3.0"), rel("1.0.5"), rel("1.4.2"), rel("1.1.0")],
             "1.0.0",
             false,
+            UpdateStrategy::Compatible,
         )
         .unwrap()
         .expect("the newest compatible release is chosen regardless of input order");
@@ -2264,6 +2363,7 @@ mod tests {
             ],
             "1.0.0",
             false,
+            UpdateStrategy::Compatible,
         )
         .unwrap()
         .expect("the newest parseable compatible release is chosen");
@@ -2271,9 +2371,14 @@ mod tests {
 
         // Only junk versions -> nothing selectable -> up-to-date.
         assert!(
-            choose_latest_release(vec![rel("junk"), rel("garbage")], "1.0.0", false)
-                .unwrap()
-                .is_none()
+            choose_latest_release(
+                vec![rel("junk"), rel("garbage")],
+                "1.0.0",
+                false,
+                UpdateStrategy::Compatible,
+            )
+            .unwrap()
+            .is_none()
         );
     }
 
@@ -2281,10 +2386,57 @@ mod tests {
     fn choose_latest_release_falls_back_to_incompatible_newer() {
         // Only a major bump is available: newer than current but not semver-compatible. It is still
         // offered (flagged "*NOT* compatible" in the messages), exercising the fallback branch.
-        let chosen = choose_latest_release(vec![rel("2.0.0")], "1.0.0", false)
-            .unwrap()
-            .expect("an incompatible-but-newer release is still offered");
+        let chosen = choose_latest_release(
+            vec![rel("2.0.0")],
+            "1.0.0",
+            false,
+            UpdateStrategy::Compatible,
+        )
+        .unwrap()
+        .expect("an incompatible-but-newer release is still offered");
         assert_eq!(chosen.version(), "2.0.0");
+    }
+
+    #[test]
+    fn choose_latest_release_compatible_prefers_compatible_over_newer_major() {
+        // Default `Compatible` strategy: with a newer compatible release AND a newer major both
+        // available, the compatible one wins (the #152 scenario: 1.1.x vs 2.0.0 from 1.1.1).
+        let releases = vec![rel("2.0.0"), rel("1.1.2"), rel("1.1.0")];
+        let chosen =
+            choose_latest_release(releases.clone(), "1.1.1", false, UpdateStrategy::Compatible)
+                .unwrap()
+                .expect("a newer compatible release is chosen");
+        assert_eq!(
+            chosen.version(),
+            "1.1.2",
+            "Compatible must prefer the newest semver-compatible release over a newer major"
+        );
+
+        // Same inputs under `Latest`: the newest overall wins, jumping the major.
+        let chosen = choose_latest_release(releases, "1.1.1", false, UpdateStrategy::Latest)
+            .unwrap()
+            .expect("the newest release overall is chosen");
+        assert_eq!(
+            chosen.version(),
+            "2.0.0",
+            "Latest must select the newest release overall, across a major bump"
+        );
+    }
+
+    #[test]
+    fn choose_latest_release_latest_still_up_to_date_when_nothing_newer() {
+        // `Latest` still respects the strictly-newer guard: nothing newer than current => up-to-date.
+        assert!(
+            choose_latest_release(
+                vec![rel("1.0.0"), rel("0.9.0")],
+                "1.0.0",
+                false,
+                UpdateStrategy::Latest,
+            )
+            .unwrap()
+            .is_none(),
+            "Latest must not re-install the current or an older release"
+        );
     }
 
     // --- Bound-narrowing compile locks (gap #3) -----------------------------------------------


### PR DESCRIPTION
Addresses a batch of open feature requests ahead of 1.0. Every change is additive and non-breaking.

## Changes

- Support xz archives: new `compression-tar-xz` feature decodes `.tar.xz` / `.txz` / plain `.xz` via pure-Rust `lzma-rs` (no C `liblzma`, so it cross-compiles like the rest of the default stack). Adds `Compression::Xz`. A recognized-but-unsupported compression extension now fails with `Error::CompressionNotEnabled` instead of installing the still-compressed bytes as the binary. (#143)
- Expose `self_update::verify_signature(impl AsRef<Path>, &[VerifyingKey])`: run the embedded-signature check standalone, for a caller that stages a download itself (`signatures` feature). (#150)
- Add `native-tls-vendored`: build OpenSSL from source and link it statically; implies `native-tls`, applies to the reqwest client. (#108)
- Add `UpdateStrategy` (`Compatible` default / `Latest`) and the `update_strategy(..)` setter: control which release the unpinned path installs. `Latest` jumps to the newest release across a major bump; `Compatible` prefers the newest semver-compatible one. (#152)
- Add `Release::release_notes_url()` / `ReleaseBuilder::release_notes_url(..)` (filled from `html_url`, gitlab `_links.self`; `None` for s3) and a `show_release_notes(bool)` setter that shows it (or the body) in the confirmation prompt. (#148)
- Add `tag_prefix(..)` on the github/gitlab/gitea `Update` builders for monorepo-style tags like `myapp-1.2.3`. Default trims a leading `v` as before; when set, non-matching tags are skipped instead of mis-parsed. Forge-only (s3 parses versions from object keys; the custom backend supplies its own releases). (#76)

## Notes

- #61 (pre-release versions dropped, e.g. `0.1.2-beta` read as `0.1.2`) is confirmed as an s3-only issue: the s3 asset-key regex captures `\d+\.\d+\.\d+` and cannot disambiguate a pre-release segment from the target triple in a flat key (both use `-`). The forge backends are unaffected (they parse the whole tag as semver). The intended fix is a user-supplied version-extraction pattern on the s3 builder; tracked separately.
- Deferred (all addable non-breaking post-1.0): #145 bundles, #121 gitee backend, #74 https-directory backend, #112 sudo/permissions, #79 periodic checks, #62 process restart, #78/#168 docs.

Each change ships with tests, CHANGELOG and spec updates, and a regenerated README. Validated across the default, all-features, and ureq lanes (clippy clean, fmt applied).
